### PR TITLE
fix(ci): validate changelog fragment is added in PR diff + refactor to .mjs scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,17 +83,18 @@ jobs:
 
       - name: Check for changelog fragments
         run: |
-          # Get list of fragment files (excluding README and template)
-          FRAGMENTS=$(find changelog.d -name "*.md" ! -name "README.md" 2>/dev/null | wc -l)
-
           # Get changed files in PR
           CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
 
           # Check if any source files changed (excluding docs and config)
           SOURCE_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^(src/|tests/|scripts/|Cargo\.toml)" | wc -l)
 
-          if [ "$SOURCE_CHANGED" -gt 0 ] && [ "$FRAGMENTS" -eq 0 ]; then
-            echo "::error::No changelog fragment found. Please add a changelog entry in changelog.d/"
+          # Check if a changelog fragment was ADDED in this PR (not just existing)
+          # This prevents the check from passing due to leftover fragments from previous PRs
+          FRAGMENT_ADDED=$(echo "$CHANGED_FILES" | grep -E "^changelog\.d/.*\.md$" | grep -v "README.md" | wc -l)
+
+          if [ "$SOURCE_CHANGED" -gt 0 ] && [ "$FRAGMENT_ADDED" -eq 0 ]; then
+            echo "::error::No changelog fragment found in this PR. Please add a changelog entry in changelog.d/"
             echo ""
             echo "To create a changelog fragment:"
             echo "  Create a new .md file in changelog.d/ with your changes"
@@ -102,7 +103,7 @@ jobs:
             exit 1
           fi
 
-          echo "Changelog check passed"
+          echo "Changelog check passed (source files changed: $SOURCE_CHANGED, fragments added: $FRAGMENT_ADDED)"
 
   # === LINT AND FORMAT CHECK ===
   # Lint runs independently of changelog check - it's a fast check that should always run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,29 +81,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
       - name: Check for changelog fragments
-        run: |
-          # Get changed files in PR
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
-
-          # Check if any source files changed (excluding docs and config)
-          SOURCE_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^(src/|tests/|scripts/|Cargo\.toml)" | wc -l)
-
-          # Check if a changelog fragment was ADDED in this PR (not just existing)
-          # This prevents the check from passing due to leftover fragments from previous PRs
-          FRAGMENT_ADDED=$(echo "$CHANGED_FILES" | grep -E "^changelog\.d/.*\.md$" | grep -v "README.md" | wc -l)
-
-          if [ "$SOURCE_CHANGED" -gt 0 ] && [ "$FRAGMENT_ADDED" -eq 0 ]; then
-            echo "::error::No changelog fragment found in this PR. Please add a changelog entry in changelog.d/"
-            echo ""
-            echo "To create a changelog fragment:"
-            echo "  Create a new .md file in changelog.d/ with your changes"
-            echo ""
-            echo "See changelog.d/README.md for more information."
-            exit 1
-          fi
-
-          echo "Changelog check passed (source files changed: $SOURCE_CHANGED, fragments added: $FRAGMENT_ADDED)"
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: node scripts/check-changelog-fragment.mjs
 
   # === LINT AND FORMAT CHECK ===
   # Lint runs independently of changelog check - it's a fast check that should always run
@@ -253,9 +239,7 @@ jobs:
           node-version: '20.x'
 
       - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+        run: node scripts/git-config.mjs
 
       - name: Determine bump type from changelog fragments
         id: bump_type
@@ -263,24 +247,9 @@ jobs:
 
       - name: Check if version already released or no fragments
         id: check
-        run: |
-          # Check if there are changelog fragments
-          if [ "${{ steps.bump_type.outputs.has_fragments }}" != "true" ]; then
-            # No fragments - check if current version tag exists
-            CURRENT_VERSION=$(grep -Po '(?<=^version = ")[^"]*' Cargo.toml)
-            if git rev-parse "v$CURRENT_VERSION" >/dev/null 2>&1; then
-              echo "No changelog fragments and v$CURRENT_VERSION already released"
-              echo "should_release=false" >> $GITHUB_OUTPUT
-            else
-              echo "No changelog fragments but v$CURRENT_VERSION not yet released"
-              echo "should_release=true" >> $GITHUB_OUTPUT
-              echo "skip_bump=true" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "Found changelog fragments, proceeding with release"
-            echo "should_release=true" >> $GITHUB_OUTPUT
-            echo "skip_bump=false" >> $GITHUB_OUTPUT
-          fi
+        env:
+          HAS_FRAGMENTS: ${{ steps.bump_type.outputs.has_fragments }}
+        run: node scripts/check-release-needed.mjs
 
       - name: Collect changelog and bump version
         id: version
@@ -292,9 +261,7 @@ jobs:
       - name: Get current version
         id: current_version
         if: steps.check.outputs.should_release == 'true'
-        run: |
-          CURRENT_VERSION=$(grep -Po '(?<=^version = ")[^"]*' Cargo.toml)
-          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+        run: node scripts/get-version.mjs
 
       - name: Build release
         if: steps.check.outputs.should_release == 'true'
@@ -303,53 +270,15 @@ jobs:
       - name: Publish to Crates.io
         if: steps.check.outputs.should_release == 'true'
         id: publish-crate
-        run: |
-          PACKAGE_NAME=$(grep '^name = ' Cargo.toml | head -1 | sed 's/name = "\(.*\)"/\1/')
-          PACKAGE_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          echo "Package: $PACKAGE_NAME@$PACKAGE_VERSION"
-
-          echo "=== Attempting to publish to crates.io ==="
-
-          # Try to publish and capture the result
-          set +e  # Don't exit on error
-          cargo publish --token ${{ secrets.CARGO_TOKEN }} --allow-dirty 2>&1 | tee publish_output.txt
-          PUBLISH_EXIT_CODE=$?
-          set -e  # Re-enable exit on error
-
-          if [ $PUBLISH_EXIT_CODE -eq 0 ]; then
-            echo "Successfully published $PACKAGE_NAME@$PACKAGE_VERSION to crates.io"
-            echo "publish_result=success" >> $GITHUB_OUTPUT
-          elif grep -q "already uploaded" publish_output.txt || grep -q "already exists" publish_output.txt; then
-            echo "Version $PACKAGE_VERSION already exists on crates.io - this is OK"
-            echo "publish_result=already_exists" >> $GITHUB_OUTPUT
-          else
-            echo "Failed to publish for unknown reason"
-            cat publish_output.txt
-            echo "publish_result=failed" >> $GITHUB_OUTPUT
-            exit 1
-          fi
-
-      - name: Report crates.io publish status
-        if: steps.check.outputs.should_release == 'true'
-        run: |
-          if [ "${{ steps.publish-crate.outputs.publish_result }}" = "success" ]; then
-            echo "Package was successfully published to crates.io"
-          elif [ "${{ steps.publish-crate.outputs.publish_result }}" = "already_exists" ]; then
-            echo "Package version already exists on crates.io - no action needed"
-          else
-            echo "Publishing to crates.io failed - please check the logs"
-          fi
+        env:
+          CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+        run: node scripts/publish-crate.mjs
 
       - name: Create GitHub Release
         if: steps.check.outputs.should_release == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PACKAGE_NAME=$(grep '^name = ' Cargo.toml | head -1 | sed 's/name = "\(.*\)"/\1/')
-          node scripts/create-github-release.mjs \
-            --release-version "${{ steps.current_version.outputs.version }}" \
-            --repository "${{ github.repository }}" \
-            --crates-io-url "https://crates.io/crates/$PACKAGE_NAME"
+        run: node scripts/create-github-release.mjs --release-version "${{ steps.current_version.outputs.version }}" --repository "${{ github.repository }}"
 
   # === MANUAL INSTANT RELEASE ===
   # Manual release via workflow_dispatch - only after CI passes
@@ -381,27 +310,17 @@ jobs:
           node-version: '20.x'
 
       - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+        run: node scripts/git-config.mjs
 
       - name: Collect changelog fragments
-        run: |
-          # Check if there are any fragments to collect
-          FRAGMENTS=$(find changelog.d -name "*.md" ! -name "README.md" 2>/dev/null | wc -l)
-          if [ "$FRAGMENTS" -gt 0 ]; then
-            echo "Found $FRAGMENTS changelog fragment(s), collecting..."
-            node scripts/collect-changelog.mjs
-          else
-            echo "No changelog fragments found, skipping collection"
-          fi
+        run: node scripts/collect-changelog.mjs
 
       - name: Version and commit
         id: version
-        run: |
-          node scripts/version-and-commit.mjs \
-            --bump-type "${{ github.event.inputs.bump_type }}" \
-            --description "${{ github.event.inputs.description }}"
+        env:
+          BUMP_TYPE: ${{ github.event.inputs.bump_type }}
+          DESCRIPTION: ${{ github.event.inputs.description }}
+        run: node scripts/version-and-commit.mjs --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}"
 
       - name: Build release
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
@@ -410,53 +329,15 @@ jobs:
       - name: Publish to Crates.io
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         id: publish-crate
-        run: |
-          PACKAGE_NAME=$(grep '^name = ' Cargo.toml | head -1 | sed 's/name = "\(.*\)"/\1/')
-          PACKAGE_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          echo "Package: $PACKAGE_NAME@$PACKAGE_VERSION"
-
-          echo "=== Attempting to publish to crates.io ==="
-
-          # Try to publish and capture the result
-          set +e  # Don't exit on error
-          cargo publish --token ${{ secrets.CARGO_TOKEN }} --allow-dirty 2>&1 | tee publish_output.txt
-          PUBLISH_EXIT_CODE=$?
-          set -e  # Re-enable exit on error
-
-          if [ $PUBLISH_EXIT_CODE -eq 0 ]; then
-            echo "Successfully published $PACKAGE_NAME@$PACKAGE_VERSION to crates.io"
-            echo "publish_result=success" >> $GITHUB_OUTPUT
-          elif grep -q "already uploaded" publish_output.txt || grep -q "already exists" publish_output.txt; then
-            echo "Version $PACKAGE_VERSION already exists on crates.io - this is OK"
-            echo "publish_result=already_exists" >> $GITHUB_OUTPUT
-          else
-            echo "Failed to publish for unknown reason"
-            cat publish_output.txt
-            echo "publish_result=failed" >> $GITHUB_OUTPUT
-            exit 1
-          fi
-
-      - name: Report crates.io publish status
-        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
-        run: |
-          if [ "${{ steps.publish-crate.outputs.publish_result }}" = "success" ]; then
-            echo "Package was successfully published to crates.io"
-          elif [ "${{ steps.publish-crate.outputs.publish_result }}" = "already_exists" ]; then
-            echo "Package version already exists on crates.io - no action needed"
-          else
-            echo "Publishing to crates.io failed - please check the logs"
-          fi
+        env:
+          CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+        run: node scripts/publish-crate.mjs
 
       - name: Create GitHub Release
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PACKAGE_NAME=$(grep '^name = ' Cargo.toml | head -1 | sed 's/name = "\(.*\)"/\1/')
-          node scripts/create-github-release.mjs \
-            --release-version "${{ steps.version.outputs.new_version }}" \
-            --repository "${{ github.repository }}" \
-            --crates-io-url "https://crates.io/crates/$PACKAGE_NAME"
+        run: node scripts/create-github-release.mjs --release-version "${{ steps.version.outputs.new_version }}" --repository "${{ github.repository }}"
 
   # === MANUAL CHANGELOG PR ===
   changelog-pr:
@@ -477,44 +358,10 @@ jobs:
           node-version: '20.x'
 
       - name: Create changelog fragment
-        run: |
-          BUMP_TYPE="${{ github.event.inputs.bump_type }}"
-          DESCRIPTION="${{ github.event.inputs.description }}"
-          TIMESTAMP=$(date +%Y%m%d%H%M%S)
-          FRAGMENT_FILE="changelog.d/${TIMESTAMP}-manual-${BUMP_TYPE}.md"
-
-          # Determine changelog category based on bump type
-          case "$BUMP_TYPE" in
-            major)
-              CATEGORY="### Breaking Changes"
-              ;;
-            minor)
-              CATEGORY="### Added"
-              ;;
-            patch)
-              CATEGORY="### Fixed"
-              ;;
-          esac
-
-          # Create changelog fragment with frontmatter
-          mkdir -p changelog.d
-          cat > "$FRAGMENT_FILE" << EOF
-          ---
-          bump: $BUMP_TYPE
-          ---
-
-          $CATEGORY
-
-          EOF
-
-          if [ -n "$DESCRIPTION" ]; then
-            echo "- ${DESCRIPTION}" >> "$FRAGMENT_FILE"
-          else
-            echo "- Manual ${BUMP_TYPE} release" >> "$FRAGMENT_FILE"
-          fi
-
-          echo "Created changelog fragment: $FRAGMENT_FILE"
-          cat "$FRAGMENT_FILE"
+        env:
+          BUMP_TYPE: ${{ github.event.inputs.bump_type }}
+          DESCRIPTION: ${{ github.event.inputs.description }}
+        run: node scripts/create-changelog-fragment.mjs --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/13
-Your prepared branch: issue-13-a37fa10f34b6
-Your prepared working directory: /tmp/gh-issue-solver-1767888604790
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/13
+Your prepared branch: issue-13-a37fa10f34b6
+Your prepared working directory: /tmp/gh-issue-solver-1767888604790
+
+Proceed.

--- a/changelog.d/20260108_171124_fix_changelog_check.md
+++ b/changelog.d/20260108_171124_fix_changelog_check.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Fixed changelog fragment check to validate that a fragment is **added in the PR diff** rather than just checking if any fragments exist in the directory. This prevents the check from incorrectly passing when there are leftover fragments from previous PRs that haven't been released yet.

--- a/changelog.d/20260108_171124_fix_changelog_check.md
+++ b/changelog.d/20260108_171124_fix_changelog_check.md
@@ -5,3 +5,13 @@ bump: patch
 ### Fixed
 
 - Fixed changelog fragment check to validate that a fragment is **added in the PR diff** rather than just checking if any fragments exist in the directory. This prevents the check from incorrectly passing when there are leftover fragments from previous PRs that haven't been released yet.
+
+### Changed
+
+- Converted shell scripts in `release.yml` to cross-platform `.mjs` scripts for improved portability and performance:
+  - `check-changelog-fragment.mjs` - validates changelog fragment is added in PR diff
+  - `git-config.mjs` - configures git user for CI/CD
+  - `check-release-needed.mjs` - checks if release is needed
+  - `publish-crate.mjs` - publishes package to crates.io
+  - `create-changelog-fragment.mjs` - creates changelog fragments for manual releases
+  - `get-version.mjs` - gets current version from Cargo.toml

--- a/scripts/check-changelog-fragment.mjs
+++ b/scripts/check-changelog-fragment.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+/**
+ * Check if a changelog fragment was added in the current PR
+ *
+ * This script validates that a changelog fragment is added in the PR diff,
+ * not just checking if any fragments exist in the directory. This prevents
+ * the check from incorrectly passing when there are leftover fragments
+ * from previous PRs that haven't been released yet.
+ *
+ * Usage: node scripts/check-changelog-fragment.mjs
+ *
+ * Environment variables (set by GitHub Actions):
+ *   - GITHUB_BASE_REF: Base branch name for PR (e.g., "main")
+ *
+ * Exit codes:
+ *   - 0: Check passed (fragment added or no source changes)
+ *   - 1: Check failed (source changes without changelog fragment)
+ */
+
+import { execSync } from 'child_process';
+
+/**
+ * Execute a shell command and return trimmed output
+ * @param {string} command - The command to execute
+ * @returns {string} - The trimmed command output
+ */
+function exec(command) {
+  try {
+    return execSync(command, { encoding: 'utf-8' }).trim();
+  } catch (error) {
+    console.error(`Error executing command: ${command}`);
+    console.error(error.message);
+    return '';
+  }
+}
+
+/**
+ * Get the list of changed files in the PR
+ * @returns {string[]} Array of changed file paths
+ */
+function getChangedFiles() {
+  const baseRef = process.env.GITHUB_BASE_REF || 'main';
+  console.log(`Comparing against origin/${baseRef}...HEAD`);
+
+  try {
+    const output = exec(`git diff --name-only origin/${baseRef}...HEAD`);
+    return output ? output.split('\n').filter(Boolean) : [];
+  } catch (error) {
+    console.error(`Git diff failed: ${error.message}`);
+    return [];
+  }
+}
+
+/**
+ * Check if a file is a source file that requires a changelog fragment
+ * @param {string} filePath - The file path to check
+ * @returns {boolean} True if the file is a source file
+ */
+function isSourceFile(filePath) {
+  // Source files that require changelog fragments
+  const sourcePatterns = [
+    /^src\//,
+    /^tests\//,
+    /^scripts\//,
+    /^Cargo\.toml$/,
+  ];
+
+  return sourcePatterns.some((pattern) => pattern.test(filePath));
+}
+
+/**
+ * Check if a file is a changelog fragment
+ * @param {string} filePath - The file path to check
+ * @returns {boolean} True if the file is a changelog fragment
+ */
+function isChangelogFragment(filePath) {
+  // Changelog fragments are .md files in changelog.d/ (excluding README.md)
+  return (
+    filePath.startsWith('changelog.d/') &&
+    filePath.endsWith('.md') &&
+    !filePath.endsWith('README.md')
+  );
+}
+
+/**
+ * Main function to check changelog fragments
+ */
+function checkChangelogFragment() {
+  console.log('Checking for changelog fragment in PR diff...\n');
+
+  const changedFiles = getChangedFiles();
+
+  if (changedFiles.length === 0) {
+    console.log('No changed files found');
+    process.exit(0);
+  }
+
+  console.log('Changed files:');
+  changedFiles.forEach((file) => console.log(`  ${file}`));
+  console.log('');
+
+  // Count source files changed
+  const sourceChanges = changedFiles.filter(isSourceFile);
+  const sourceChangedCount = sourceChanges.length;
+
+  console.log(`Source files changed: ${sourceChangedCount}`);
+  if (sourceChangedCount > 0) {
+    sourceChanges.forEach((file) => console.log(`  ${file}`));
+  }
+  console.log('');
+
+  // Count changelog fragments added in this PR
+  const fragmentsAdded = changedFiles.filter(isChangelogFragment);
+  const fragmentAddedCount = fragmentsAdded.length;
+
+  console.log(`Changelog fragments added: ${fragmentAddedCount}`);
+  if (fragmentAddedCount > 0) {
+    fragmentsAdded.forEach((file) => console.log(`  ${file}`));
+  }
+  console.log('');
+
+  // Check if source files changed but no fragment was added
+  if (sourceChangedCount > 0 && fragmentAddedCount === 0) {
+    console.error(
+      '::error::No changelog fragment found in this PR. Please add a changelog entry in changelog.d/'
+    );
+    console.error('');
+    console.error('To create a changelog fragment:');
+    console.error(
+      '  Create a new .md file in changelog.d/ with your changes'
+    );
+    console.error('');
+    console.error('See changelog.d/README.md for more information.');
+    process.exit(1);
+  }
+
+  console.log(
+    `Changelog check passed (source files changed: ${sourceChangedCount}, fragments added: ${fragmentAddedCount})`
+  );
+}
+
+// Run the check
+checkChangelogFragment();

--- a/scripts/check-release-needed.mjs
+++ b/scripts/check-release-needed.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+
+/**
+ * Check if a release is needed based on changelog fragments and version state
+ *
+ * This script checks:
+ * 1. If there are changelog fragments to process
+ * 2. If the current version has already been released (tagged)
+ *
+ * Usage: node scripts/check-release-needed.mjs
+ *
+ * Environment variables:
+ *   - HAS_FRAGMENTS: 'true' if changelog fragments exist (from get-bump-type.mjs)
+ *
+ * Outputs (written to GITHUB_OUTPUT):
+ *   - should_release: 'true' if a release should be created
+ *   - skip_bump: 'true' if version bump should be skipped (version not yet released)
+ *
+ * Uses link-foundation libraries:
+ * - use-m: Dynamic package loading without package.json dependencies
+ * - command-stream: Modern shell command execution with streaming support
+ * - lino-arguments: Unified configuration from CLI args, env vars, and .lenv files
+ */
+
+import { readFileSync, appendFileSync } from 'fs';
+
+// Load use-m dynamically
+const { use } = eval(
+  await (await fetch('https://unpkg.com/use-m/use.js')).text()
+);
+
+// Import link-foundation libraries
+const { $ } = await use('command-stream');
+const { makeConfig } = await use('lino-arguments');
+
+// Parse CLI arguments and env vars
+const config = makeConfig({
+  yargs: ({ yargs, getenv }) =>
+    yargs.option('has-fragments', {
+      type: 'string',
+      default: getenv('HAS_FRAGMENTS', 'false'),
+      describe: 'Whether changelog fragments exist',
+    }),
+});
+
+const { hasFragments } = config;
+
+/**
+ * Append to GitHub Actions output file
+ * @param {string} key
+ * @param {string} value
+ */
+function setOutput(key, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${key}=${value}\n`);
+  }
+  console.log(`Output: ${key}=${value}`);
+}
+
+/**
+ * Get current version from Cargo.toml
+ * @returns {string}
+ */
+function getCurrentVersion() {
+  const cargoToml = readFileSync('Cargo.toml', 'utf-8');
+  const match = cargoToml.match(/^version\s*=\s*"([^"]+)"/m);
+
+  if (!match) {
+    console.error('Error: Could not find version in Cargo.toml');
+    process.exit(1);
+  }
+
+  return match[1];
+}
+
+/**
+ * Check if a git tag exists for this version
+ * @param {string} version
+ * @returns {Promise<boolean>}
+ */
+async function checkTagExists(version) {
+  try {
+    await $`git rev-parse v${version}`.run({ capture: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  try {
+    const fragmentsExist = hasFragments === 'true';
+
+    if (!fragmentsExist) {
+      // No fragments - check if current version tag exists
+      const currentVersion = getCurrentVersion();
+      const tagExists = await checkTagExists(currentVersion);
+
+      if (tagExists) {
+        console.log(
+          `No changelog fragments and v${currentVersion} already released`
+        );
+        setOutput('should_release', 'false');
+      } else {
+        console.log(
+          `No changelog fragments but v${currentVersion} not yet released`
+        );
+        setOutput('should_release', 'true');
+        setOutput('skip_bump', 'true');
+      }
+    } else {
+      console.log('Found changelog fragments, proceeding with release');
+      setOutput('should_release', 'true');
+      setOutput('skip_bump', 'false');
+    }
+  } catch (error) {
+    console.error('Error:', error.message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/create-changelog-fragment.mjs
+++ b/scripts/create-changelog-fragment.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+/**
+ * Create a changelog fragment for manual release PR
+ *
+ * This script creates a changelog fragment with the appropriate
+ * category based on the bump type.
+ *
+ * Usage: node scripts/create-changelog-fragment.mjs --bump-type <type> [--description <desc>]
+ *
+ * Uses link-foundation libraries:
+ * - use-m: Dynamic package loading without package.json dependencies
+ * - lino-arguments: Unified configuration from CLI args, env vars, and .lenv files
+ */
+
+import { writeFileSync, mkdirSync, existsSync } from 'fs';
+import { join } from 'path';
+
+// Load use-m dynamically
+const { use } = eval(
+  await (await fetch('https://unpkg.com/use-m/use.js')).text()
+);
+
+// Import lino-arguments for CLI argument parsing
+const { makeConfig } = await use('lino-arguments');
+
+// Parse CLI arguments
+const config = makeConfig({
+  yargs: ({ yargs, getenv }) =>
+    yargs
+      .option('bump-type', {
+        type: 'string',
+        default: getenv('BUMP_TYPE', 'patch'),
+        describe: 'Version bump type',
+        choices: ['major', 'minor', 'patch'],
+      })
+      .option('description', {
+        type: 'string',
+        default: getenv('DESCRIPTION', ''),
+        describe: 'Release description',
+      }),
+});
+
+const { bumpType, description } = config;
+
+/**
+ * Get the changelog category based on bump type
+ * @param {string} bumpType
+ * @returns {string}
+ */
+function getCategory(bumpType) {
+  switch (bumpType) {
+    case 'major':
+      return '### Breaking Changes';
+    case 'minor':
+      return '### Added';
+    case 'patch':
+      return '### Fixed';
+    default:
+      return '### Changed';
+  }
+}
+
+/**
+ * Generate a timestamp-based filename
+ * @returns {string}
+ */
+function generateTimestamp() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  const hours = String(now.getHours()).padStart(2, '0');
+  const minutes = String(now.getMinutes()).padStart(2, '0');
+  const seconds = String(now.getSeconds()).padStart(2, '0');
+  return `${year}${month}${day}${hours}${minutes}${seconds}`;
+}
+
+try {
+  const changelogDir = 'changelog.d';
+  const timestamp = generateTimestamp();
+  const fragmentFile = join(changelogDir, `${timestamp}-manual-${bumpType}.md`);
+
+  // Determine changelog category based on bump type
+  const category = getCategory(bumpType);
+
+  // Create changelog fragment with frontmatter
+  const descriptionText = description || `Manual ${bumpType} release`;
+  const fragmentContent = `---
+bump: ${bumpType}
+---
+
+${category}
+
+- ${descriptionText}
+`;
+
+  // Ensure changelog.d directory exists
+  if (!existsSync(changelogDir)) {
+    mkdirSync(changelogDir, { recursive: true });
+  }
+
+  // Write the fragment file
+  writeFileSync(fragmentFile, fragmentContent, 'utf-8');
+
+  console.log(`Created changelog fragment: ${fragmentFile}`);
+  console.log('');
+  console.log('Content:');
+  console.log(fragmentContent);
+} catch (error) {
+  console.error('Error:', error.message);
+  process.exit(1);
+}

--- a/scripts/get-version.mjs
+++ b/scripts/get-version.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+/**
+ * Get the current version from Cargo.toml
+ *
+ * This script reads the version from Cargo.toml and outputs it
+ * for use in GitHub Actions.
+ *
+ * Usage: node scripts/get-version.mjs
+ *
+ * Outputs (written to GITHUB_OUTPUT):
+ *   - version: The current version from Cargo.toml
+ */
+
+import { readFileSync, appendFileSync } from 'fs';
+
+/**
+ * Append to GitHub Actions output file
+ * @param {string} key
+ * @param {string} value
+ */
+function setOutput(key, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${key}=${value}\n`);
+  }
+  console.log(`Output: ${key}=${value}`);
+}
+
+/**
+ * Get current version from Cargo.toml
+ * @returns {string}
+ */
+function getCurrentVersion() {
+  const cargoToml = readFileSync('Cargo.toml', 'utf-8');
+  const match = cargoToml.match(/^version\s*=\s*"([^"]+)"/m);
+
+  if (!match) {
+    console.error('Error: Could not find version in Cargo.toml');
+    process.exit(1);
+  }
+
+  return match[1];
+}
+
+try {
+  const version = getCurrentVersion();
+  console.log(`Current version: ${version}`);
+  setOutput('version', version);
+} catch (error) {
+  console.error('Error:', error.message);
+  process.exit(1);
+}

--- a/scripts/git-config.mjs
+++ b/scripts/git-config.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+/**
+ * Configure git user for CI/CD pipeline
+ *
+ * This script sets up the git user name and email for automated commits.
+ * It's used by the CI/CD pipeline before making commits.
+ *
+ * Usage: node scripts/git-config.mjs [--name <name>] [--email <email>]
+ *
+ * Uses link-foundation libraries:
+ * - use-m: Dynamic package loading without package.json dependencies
+ * - command-stream: Modern shell command execution with streaming support
+ * - lino-arguments: Unified configuration from CLI args, env vars, and .lenv files
+ */
+
+// Load use-m dynamically
+const { use } = eval(
+  await (await fetch('https://unpkg.com/use-m/use.js')).text()
+);
+
+// Import link-foundation libraries
+const { $ } = await use('command-stream');
+const { makeConfig } = await use('lino-arguments');
+
+// Parse CLI arguments
+const config = makeConfig({
+  yargs: ({ yargs, getenv }) =>
+    yargs
+      .option('name', {
+        type: 'string',
+        default: getenv('GIT_USER_NAME', 'github-actions[bot]'),
+        describe: 'Git user name',
+      })
+      .option('email', {
+        type: 'string',
+        default: getenv(
+          'GIT_USER_EMAIL',
+          'github-actions[bot]@users.noreply.github.com'
+        ),
+        describe: 'Git user email',
+      }),
+});
+
+const { name, email } = config;
+
+try {
+  console.log(`Configuring git user: ${name} <${email}>`);
+
+  await $`git config user.name ${name}`;
+  await $`git config user.email ${email}`;
+
+  console.log('Git configuration complete');
+} catch (error) {
+  console.error('Error configuring git:', error.message);
+  process.exit(1);
+}

--- a/scripts/publish-crate.mjs
+++ b/scripts/publish-crate.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+/**
+ * Publish package to crates.io
+ *
+ * This script publishes the Rust package to crates.io and handles
+ * the case where the version already exists.
+ *
+ * Usage: node scripts/publish-crate.mjs [--token <token>]
+ *
+ * Environment variables:
+ *   - CARGO_TOKEN: The crates.io API token
+ *
+ * Outputs (written to GITHUB_OUTPUT):
+ *   - publish_result: 'success', 'already_exists', or 'failed'
+ *
+ * Uses link-foundation libraries:
+ * - use-m: Dynamic package loading without package.json dependencies
+ * - command-stream: Modern shell command execution with streaming support
+ * - lino-arguments: Unified configuration from CLI args, env vars, and .lenv files
+ */
+
+import { readFileSync, appendFileSync } from 'fs';
+
+// Load use-m dynamically
+const { use } = eval(
+  await (await fetch('https://unpkg.com/use-m/use.js')).text()
+);
+
+// Import link-foundation libraries
+const { $ } = await use('command-stream');
+const { makeConfig } = await use('lino-arguments');
+
+// Parse CLI arguments
+const config = makeConfig({
+  yargs: ({ yargs, getenv }) =>
+    yargs.option('token', {
+      type: 'string',
+      default: getenv('CARGO_TOKEN', ''),
+      describe: 'Crates.io API token',
+    }),
+});
+
+const { token } = config;
+
+/**
+ * Append to GitHub Actions output file
+ * @param {string} key
+ * @param {string} value
+ */
+function setOutput(key, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${key}=${value}\n`);
+  }
+  console.log(`Output: ${key}=${value}`);
+}
+
+/**
+ * Get package info from Cargo.toml
+ * @returns {{name: string, version: string}}
+ */
+function getPackageInfo() {
+  const cargoToml = readFileSync('Cargo.toml', 'utf-8');
+
+  const nameMatch = cargoToml.match(/^name\s*=\s*"([^"]+)"/m);
+  const versionMatch = cargoToml.match(/^version\s*=\s*"([^"]+)"/m);
+
+  if (!nameMatch || !versionMatch) {
+    console.error('Error: Could not parse package info from Cargo.toml');
+    process.exit(1);
+  }
+
+  return {
+    name: nameMatch[1],
+    version: versionMatch[1],
+  };
+}
+
+async function main() {
+  try {
+    const { name, version } = getPackageInfo();
+    console.log(`Package: ${name}@${version}`);
+    console.log('');
+    console.log('=== Attempting to publish to crates.io ===');
+
+    try {
+      if (token) {
+        await $`cargo publish --token ${token} --allow-dirty`;
+      } else {
+        await $`cargo publish --allow-dirty`;
+      }
+
+      console.log(`Successfully published ${name}@${version} to crates.io`);
+      setOutput('publish_result', 'success');
+    } catch (error) {
+      const errorMessage = error.message || '';
+
+      if (
+        errorMessage.includes('already uploaded') ||
+        errorMessage.includes('already exists')
+      ) {
+        console.log(
+          `Version ${version} already exists on crates.io - this is OK`
+        );
+        setOutput('publish_result', 'already_exists');
+      } else {
+        console.error('Failed to publish for unknown reason');
+        console.error(errorMessage);
+        setOutput('publish_result', 'failed');
+        process.exit(1);
+      }
+    }
+  } catch (error) {
+    console.error('Error:', error.message);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

- Fixed changelog fragment check to validate that a fragment is **added in the PR diff** rather than just checking if any fragments exist in the directory
- Converted all long shell scripts in `release.yml` to cross-platform `.mjs` scripts for improved portability and performance

## Problem

The previous implementation used `find changelog.d -name "*.md"` to count existing fragments. This meant that if there were any existing changelog fragments from previous PRs that hadn't been released yet, the check would pass even if the current PR didn't add a new fragment.

Additionally, the workflow contained multiple long shell scripts that were not cross-platform and harder to maintain.

## Solution

### Changelog Fragment Check Fix

Changed the logic to check the PR diff for added files:

```bash
# Before (counting existing files):
FRAGMENTS=$(find changelog.d -name "*.md" ! -name "README.md" 2>/dev/null | wc -l)

# After (checking PR diff for additions using .mjs script):
node scripts/check-changelog-fragment.mjs
```

### Script Conversion

Converted shell scripts to `.mjs` scripts following the existing repository patterns:

| Script | Purpose |
|--------|---------|
| `check-changelog-fragment.mjs` | Validates changelog fragment is added in PR diff |
| `git-config.mjs` | Configures git user for CI/CD |
| `check-release-needed.mjs` | Checks if release is needed based on fragments and tags |
| `publish-crate.mjs` | Publishes package to crates.io with error handling |
| `create-changelog-fragment.mjs` | Creates changelog fragments for manual releases |
| `get-version.mjs` | Gets current version from Cargo.toml |

## Test plan

- [x] Local CI checks pass (cargo fmt, clippy, tests)
- [x] GitHub Actions CI passes on this PR
- [x] Scripts tested locally with various scenarios

## Related

Fixes #13

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)