### PR TITLE
feat(ci): prevent manual version modification in pull requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,29 @@ jobs:
 
           echo "Changelog check passed"
 
+  # === VERSION CHECK - prevents manual version modification in PRs ===
+  # This ensures versions are only modified by the automated release pipeline
+  version-check:
+    name: Version Modification Check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Check for manual version changes
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: node scripts/check-version-modification.mjs
+
   # === LINT AND FORMAT CHECK ===
   # Lint runs independently of changelog check - it's a fast check that should always run
   # See: https://github.com/link-assistant/hive-mind/pull/1024 for why this dependency was removed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/14
+Your prepared branch: issue-14-9d4fe6371f90
+Your prepared working directory: /tmp/gh-issue-solver-1767888659626
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/14
-Your prepared branch: issue-14-9d4fe6371f90
-Your prepared working directory: /tmp/gh-issue-solver-1767888659626
-
-Proceed.

--- a/changelog.d/20260108_171435_prevent_manual_version_modification.md
+++ b/changelog.d/20260108_171435_prevent_manual_version_modification.md
@@ -1,0 +1,13 @@
+---
+bump: minor
+---
+
+### Added
+
+- Added `check-version-modification.mjs` script to detect manual version changes in Cargo.toml
+- Added `version-check` job to CI/CD workflow that runs on pull requests
+- Added skip logic for automated release branches (changelog-manual-release-*, changeset-release/*, release/*, automated-release/*)
+
+### Changed
+
+- Version modifications in Cargo.toml are now blocked in pull requests to enforce automated release pipeline

--- a/experiments/test-version-check-dependencies.sh
+++ b/experiments/test-version-check-dependencies.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Test script for version check - dependency changes only (no version change)
+
+echo "=== Test: Cargo.toml changed but NOT version ==="
+# Save original
+cp Cargo.toml Cargo.toml.bak
+
+# Create a temporary commit with non-version change
+git checkout -b test-deps-change-branch 2>/dev/null || git checkout test-deps-change-branch 2>/dev/null
+echo '# Test comment' >> Cargo.toml
+git add Cargo.toml
+git commit -m "Test dependency change" --no-verify 2>/dev/null || true
+
+# Run the check
+GITHUB_EVENT_NAME=pull_request GITHUB_HEAD_REF=test-deps-change-branch GITHUB_BASE_REF=main node scripts/check-version-modification.mjs
+echo "Exit code: $?"
+
+# Restore
+git checkout issue-14-9d4fe6371f90 2>/dev/null
+cp Cargo.toml.bak Cargo.toml
+rm Cargo.toml.bak
+git branch -D test-deps-change-branch 2>/dev/null || true

--- a/experiments/test-version-check.sh
+++ b/experiments/test-version-check.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Test script for version check
+
+echo "=== Test 1: No version change in Cargo.toml ==="
+GITHUB_EVENT_NAME=pull_request GITHUB_HEAD_REF=test-branch GITHUB_BASE_REF=main node scripts/check-version-modification.mjs
+echo "Exit code: $?"
+echo ""
+
+echo "=== Test 2: Automated release branch (should skip) ==="
+GITHUB_EVENT_NAME=pull_request GITHUB_HEAD_REF=changelog-manual-release-12345 GITHUB_BASE_REF=main node scripts/check-version-modification.mjs
+echo "Exit code: $?"
+echo ""
+
+echo "=== Test 3: Non-PR event (should skip) ==="
+GITHUB_EVENT_NAME=push GITHUB_HEAD_REF=main GITHUB_BASE_REF=main node scripts/check-version-modification.mjs
+echo "Exit code: $?"
+echo ""
+
+echo "=== Test 4: Simulating version change ==="
+# Save original
+cp Cargo.toml Cargo.toml.bak
+
+# Create a temporary commit with version change
+git checkout -b test-version-change-branch 2>/dev/null || git checkout test-version-change-branch 2>/dev/null
+sed -i 's/version = "0.1.0"/version = "0.2.0"/' Cargo.toml
+git add Cargo.toml
+git commit -m "Test version change" --no-verify 2>/dev/null || true
+
+# Run the check
+GITHUB_EVENT_NAME=pull_request GITHUB_HEAD_REF=test-version-change-branch GITHUB_BASE_REF=main node scripts/check-version-modification.mjs
+echo "Exit code: $?"
+
+# Restore
+git checkout issue-14-9d4fe6371f90 2>/dev/null
+cp Cargo.toml.bak Cargo.toml
+rm Cargo.toml.bak
+git branch -D test-version-change-branch 2>/dev/null || true

--- a/scripts/check-version-modification.mjs
+++ b/scripts/check-version-modification.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+/**
+ * Check for manual version modification in Cargo.toml
+ *
+ * This script prevents manual version changes in pull requests.
+ * Versions should be managed automatically by the CI/CD pipeline
+ * using changelog fragments in changelog.d/.
+ *
+ * Key behavior:
+ * - Detects if `version = "..."` line has changed in Cargo.toml
+ * - Fails the CI check if manual version change is detected
+ * - Skips check for automated release branches (changelog-manual-release-*)
+ *
+ * Usage:
+ *   node scripts/check-version-modification.mjs
+ *
+ * Environment variables (set by GitHub Actions):
+ *   - GITHUB_HEAD_REF: The head branch name for PRs
+ *   - GITHUB_BASE_REF: The base branch name for PRs
+ *   - GITHUB_EVENT_NAME: Should be 'pull_request'
+ *
+ * Exit codes:
+ *   - 0: No manual version changes detected (or check skipped)
+ *   - 1: Manual version changes detected
+ */
+
+import { execSync } from 'child_process';
+
+/**
+ * Execute a shell command and return trimmed output
+ * @param {string} command - The command to execute
+ * @returns {string} - The trimmed command output
+ */
+function exec(command) {
+  try {
+    return execSync(command, { encoding: 'utf-8' }).trim();
+  } catch (error) {
+    // Return empty string for commands that fail (like git diff with no changes)
+    return '';
+  }
+}
+
+/**
+ * Check if the current branch should skip version checking
+ * @returns {boolean} True if version check should be skipped
+ */
+function shouldSkipVersionCheck() {
+  const headRef = process.env.GITHUB_HEAD_REF || '';
+
+  // Skip for automated release PRs
+  const automatedBranchPrefixes = [
+    'changelog-manual-release-',
+    'changeset-release/',
+    'release/',
+    'automated-release/',
+  ];
+
+  for (const prefix of automatedBranchPrefixes) {
+    if (headRef.startsWith(prefix)) {
+      console.log(`Skipping version check for automated branch: ${headRef}`);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Get the diff for Cargo.toml between base and head
+ * @returns {string} The diff output
+ */
+function getCargoTomlDiff() {
+  const baseRef = process.env.GITHUB_BASE_REF || 'main';
+
+  // Ensure we have the base branch
+  try {
+    execSync(`git fetch origin ${baseRef} --depth=1`, { stdio: 'ignore' });
+  } catch {
+    // Ignore fetch errors - base might already be available
+  }
+
+  // Get the diff for Cargo.toml
+  const diff = exec(`git diff origin/${baseRef}...HEAD -- Cargo.toml`);
+  return diff;
+}
+
+/**
+ * Check if the diff contains version line changes
+ * @param {string} diff - The git diff output
+ * @returns {boolean} True if version was modified
+ */
+function hasVersionChange(diff) {
+  if (!diff) {
+    return false;
+  }
+
+  // Look for changes to the version line
+  // Match lines that start with + or - followed by version = "..."
+  const versionChangePattern = /^[+-]version\s*=\s*"/m;
+  return versionChangePattern.test(diff);
+}
+
+/**
+ * Main function
+ */
+function main() {
+  console.log('Checking for manual version modifications in Cargo.toml...\n');
+
+  // Only run on pull requests
+  const eventName = process.env.GITHUB_EVENT_NAME || '';
+  if (eventName !== 'pull_request') {
+    console.log(`Skipping: Not a pull request event (event: ${eventName})`);
+    process.exit(0);
+  }
+
+  // Skip for automated release branches
+  if (shouldSkipVersionCheck()) {
+    process.exit(0);
+  }
+
+  // Get and check the diff
+  const diff = getCargoTomlDiff();
+
+  if (!diff) {
+    console.log('No changes to Cargo.toml detected.');
+    console.log('Version check passed.');
+    process.exit(0);
+  }
+
+  // Check for version changes
+  if (hasVersionChange(diff)) {
+    console.error('Error: Manual version change detected in Cargo.toml!\n');
+    console.error('Versions are managed automatically by the CI/CD pipeline.');
+    console.error('Please do not modify the version field directly.\n');
+    console.error('To trigger a release, add a changelog fragment to changelog.d/');
+    console.error('with the appropriate bump type (major, minor, or patch).\n');
+    console.error('See changelog.d/README.md for more information.\n');
+    console.error('If you need to undo your version change, run:');
+    console.error('  git checkout origin/main -- Cargo.toml');
+    process.exit(1);
+  }
+
+  console.log('Cargo.toml was modified but version field was not changed.');
+  console.log('Version check passed.');
+  process.exit(0);
+}
+
+// Run the check
+main();


### PR DESCRIPTION
## Summary

- Add `check-version-modification.mjs` script to detect manual version changes in `Cargo.toml`
- Add `version-check` job to CI/CD workflow that runs on pull requests
- Skip check for automated release branches (`changelog-manual-release-*`, `changeset-release/*`, `release/*`, `automated-release/*`)
- Include test scripts in `experiments/` folder for validation

This ensures versions in `Cargo.toml` are only modified by the automated release pipeline using changelog fragments in `changelog.d/`.

## Test plan

- [x] Test version check script passes when no version change detected
- [x] Test version check script fails when manual version change is made
- [x] Test version check skips for automated release branches
- [x] Test version check skips for non-PR events (push, workflow_dispatch)
- [x] Verify CI pipeline passes with new version-check job

## Issue Reference

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)