### PR TITLE
fix: check crates.io instead of git tags in version-and-commit.rs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -405,3 +405,33 @@ jobs:
             1. Review the changelog fragment in this PR
             2. Merge this PR to main
             3. The automated release workflow will publish to crates.io and create a GitHub release
+
+  # === DEPLOY DOCUMENTATION ===
+  # Deploy Rust API documentation to GitHub Pages after a successful release
+  deploy-docs:
+    name: Deploy Documentation
+    needs: [auto-release, manual-release]
+    if: |
+      always() && !cancelled() && (
+        needs.auto-release.result == 'success' ||
+        needs.manual-release.result == 'success'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build documentation
+        run: cargo doc --no-deps --all-features
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: target/doc

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-13T06:48:19.911Z for PR creation at branch issue-25-3ae800ec54f1 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/25

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-13T06:48:19.911Z for PR creation at branch issue-25-3ae800ec54f1 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/25

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "my-package"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "tokio",
  "tokio-test",

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A comprehensive template for AI-driven Rust development with full CI/CD pipeline support.
 
 [![CI/CD Pipeline](https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/workflows/CI%2FCD%20Pipeline/badge.svg)](https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/actions)
+[![Crates.io](https://img.shields.io/crates/v/my-package?label=crates.io&style=flat)](https://crates.io/crates/my-package)
+[![Docs.rs](https://docs.rs/my-package/badge.svg)](https://docs.rs/my-package)
 [![Rust Version](https://img.shields.io/badge/rust-1.70%2B-blue.svg)](https://www.rust-lang.org/)
 [![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](http://unlicense.org/)
 

--- a/changelog.d/20260413_fix_crates_io_check.md
+++ b/changelog.d/20260413_fix_crates_io_check.md
@@ -1,0 +1,16 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Fixed `version-and-commit.rs` to check crates.io instead of git tags for determining if a version is already released
+- This prevents the release pipeline from getting stuck when git tags exist without corresponding crates.io publication
+
+### Added
+
+- Added `--tag-prefix` support to `version-and-commit.rs` for multi-language repository compatibility
+- Added crates.io and docs.rs badges to README.md
+- Added automatic crates.io and docs.rs badge injection in GitHub release notes
+- Added documentation deployment job to CI/CD pipeline (deploys to GitHub Pages after release)
+- Added case study documentation for issue #25

--- a/docs/case-studies/issue-25/README.md
+++ b/docs/case-studies/issue-25/README.md
@@ -1,0 +1,94 @@
+# Case Study: Issue #25 - version-and-commit.rs Checks Git Tags Instead of Crates.io
+
+## Summary
+
+The `version-and-commit.rs` script used `git rev-parse` to check if a version tag existed, then exited early with `already_released=true` if it did. This created a permanent release pipeline failure loop when GitHub releases created tags without the crate being published to crates.io.
+
+## Timeline of Events
+
+| Date | Event | Detail |
+|------|-------|--------|
+| Prior | browser-commander releases | GitHub releases v0.1.1 through v0.8.0 created tags, but crates.io publishing failed for some |
+| Prior | browser-commander#47 | Pipeline stuck at v0.4.0 on crates.io, GitHub had releases up to v0.8.0 |
+| 2026-01-17 | Issue #29 (browser-commander) | First discovery of git tag vs crates.io divergence |
+| 2026-01-17 | check-release-needed.rs fix | Script was updated to check crates.io API instead of git tags |
+| 2026-04-13 | Issue #25 (this template) | Bug reported: version-and-commit.rs still uses git tags |
+
+## Root Cause Analysis
+
+### The Bug
+
+In `version-and-commit.rs` (lines 152-154), the `check_tag_exists()` function used:
+
+```rust
+fn check_tag_exists(version: &str) -> bool {
+    exec_check("git", &["rev-parse", &format!("v{}", version)])
+}
+```
+
+This checked for git tags as a proxy for "already released", but git tags are not the correct source of truth for Rust package publication.
+
+### Why Git Tags Are Unreliable
+
+1. **GitHub releases create tags** - Creating a GitHub release via the UI or API automatically creates a git tag, even if `cargo publish` was never called
+2. **Failed publishes** - If `cargo publish` fails (auth issues, network errors), the tag may already exist from a prior step
+3. **Manual tag creation** - Developers or automation can create tags without publishing
+4. **Tag prefix mismatches** - Multi-language repos may use different tag prefixes (e.g., `rust_v1.0.0` vs `v1.0.0`)
+
+### The Failure Loop
+
+```
+1. version-and-commit.rs bumps version 0.4.0 → 0.4.1
+2. Checks tag v0.4.1 → EXISTS (from a prior GitHub-only release)
+3. Exits early WITHOUT updating Cargo.toml
+4. cargo publish tries 0.4.0 → "already exists" on crates.io
+5. Pipeline is permanently stuck — every run hits the same tag check
+```
+
+### Why check-release-needed.rs Was Already Correct
+
+The `check-release-needed.rs` script (added during issue #21 investigation) already used the correct approach — querying the crates.io API:
+
+```rust
+fn check_version_on_crates_io(crate_name: &str, version: &str) -> bool {
+    let url = format!("https://crates.io/api/v1/crates/{}/{}", crate_name, version);
+    // HTTP 200 = published, 404 = not published
+}
+```
+
+The inconsistency arose because `version-and-commit.rs` was not updated at the same time.
+
+## Solution
+
+### Changes Made
+
+1. **Replaced `check_tag_exists()` with `check_version_on_crates_io()`** in `version-and-commit.rs`
+   - Added `ureq`, `serde`, and `serde_json` dependencies
+   - Added `get_crate_name()` helper to read crate name from Cargo.toml
+   - Queries `https://crates.io/api/v1/crates/{crate_name}/{version}` API endpoint
+   - Returns `true` only if crates.io confirms the version exists
+
+2. **Added `--tag-prefix` support** to `version-and-commit.rs`
+   - Configurable tag prefix (default `"v"`) for multi-language repos
+   - Aligns with `create-github-release.rs` which already supports `--tag-prefix`
+
+3. **Added test script** (`experiments/test-crates-io-check.rs`)
+   - Validates the crates.io API check against known published and unpublished versions
+
+### Design Decisions
+
+- **On error, assume not published** - If the crates.io API is unreachable, the script assumes the version is not yet published. This is safer than incorrectly skipping a release.
+- **Consistent with check-release-needed.rs** - Both scripts now use the same approach, reducing confusion and maintenance burden.
+
+## Lessons Learned
+
+1. **Use the authoritative source of truth** - For Rust packages, crates.io is the source of truth, not git tags
+2. **Keep related scripts consistent** - When fixing a pattern in one script, audit all scripts for the same anti-pattern
+3. **Test with real API calls** - The experiment script validates the fix against actual crates.io data
+4. **Multi-language repos need tag prefixes** - Hard-coded `v` prefix breaks in monorepos with multiple languages
+
+## Related Issues
+
+- [browser-commander#47](https://github.com/link-foundation/browser-commander/issues/47) - Original discovery of the stuck pipeline
+- [browser-commander#29](https://github.com/link-foundation/browser-commander/issues/29) - First fix for git tag vs crates.io check
+- [Issue #21](../issue-21/) - Previous case study covering the same category of CI/CD issues

--- a/experiments/test-crates-io-check.rs
+++ b/experiments/test-crates-io-check.rs
@@ -1,0 +1,104 @@
+#!/usr/bin/env rust-script
+//! Test script for crates.io version check logic
+//! Validates that the check_version_on_crates_io function works correctly
+//!
+//! ```cargo
+//! [dependencies]
+//! ureq = "2"
+//! serde = { version = "1", features = ["derive"] }
+//! serde_json = "1"
+//! ```
+
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct CratesIoVersion {
+    version: Option<CratesIoVersionInfo>,
+}
+
+#[derive(Deserialize)]
+struct CratesIoVersionInfo {
+    #[allow(dead_code)]
+    num: String,
+}
+
+fn check_version_on_crates_io(crate_name: &str, version: &str) -> bool {
+    let url = format!("https://crates.io/api/v1/crates/{}/{}", crate_name, version);
+
+    match ureq::get(&url)
+        .set("User-Agent", "rust-script-version-and-commit")
+        .call()
+    {
+        Ok(response) => {
+            if response.status() == 200 {
+                if let Ok(body) = response.into_string() {
+                    if let Ok(data) = serde_json::from_str::<CratesIoVersion>(&body) {
+                        return data.version.is_some();
+                    }
+                }
+            }
+            false
+        }
+        Err(ureq::Error::Status(404, _)) => false,
+        Err(e) => {
+            eprintln!("Warning: Could not check crates.io: {}", e);
+            false
+        }
+    }
+}
+
+fn main() {
+    let mut passed = 0;
+    let mut failed = 0;
+
+    // Test 1: Known published crate version (serde 1.0.0 is guaranteed to exist)
+    print!("Test 1: Known published version (serde 1.0.0)... ");
+    let result = check_version_on_crates_io("serde", "1.0.0");
+    if result {
+        println!("PASS");
+        passed += 1;
+    } else {
+        println!("FAIL (expected true, got false)");
+        failed += 1;
+    }
+
+    // Test 2: Non-existent version of a known crate
+    print!("Test 2: Non-existent version (serde 999.999.999)... ");
+    let result = check_version_on_crates_io("serde", "999.999.999");
+    if !result {
+        println!("PASS");
+        passed += 1;
+    } else {
+        println!("FAIL (expected false, got true)");
+        failed += 1;
+    }
+
+    // Test 3: Completely non-existent crate
+    print!("Test 3: Non-existent crate (this-crate-definitely-does-not-exist-12345 0.1.0)... ");
+    let result = check_version_on_crates_io("this-crate-definitely-does-not-exist-12345", "0.1.0");
+    if !result {
+        println!("PASS");
+        passed += 1;
+    } else {
+        println!("FAIL (expected false, got true)");
+        failed += 1;
+    }
+
+    // Test 4: Another known version (regex 1.0.0)
+    print!("Test 4: Known published version (regex 1.0.0)... ");
+    let result = check_version_on_crates_io("regex", "1.0.0");
+    if result {
+        println!("PASS");
+        passed += 1;
+    } else {
+        println!("FAIL (expected true, got false)");
+        failed += 1;
+    }
+
+    println!();
+    println!("Results: {} passed, {} failed", passed, failed);
+
+    if failed > 0 {
+        std::process::exit(1);
+    }
+}

--- a/scripts/create-github-release.rs
+++ b/scripts/create-github-release.rs
@@ -1,6 +1,9 @@
 #!/usr/bin/env rust-script
 //! Create GitHub Release from CHANGELOG.md
 //!
+//! Automatically includes crates.io and docs.rs badges in release notes
+//! when the crate name can be detected from Cargo.toml.
+//!
 //! Usage: rust-script scripts/create-github-release.rs --release-version <version> --repository <repository>
 //!
 //! ```cargo
@@ -17,6 +20,36 @@ use std::path::Path;
 use std::process::{Command, Stdio, exit};
 use regex::Regex;
 use serde::Serialize;
+
+fn get_rust_root() -> String {
+    if let Some(root) = get_arg("rust-root") {
+        return root;
+    }
+
+    if Path::new("./Cargo.toml").exists() {
+        return ".".to_string();
+    }
+
+    if Path::new("./rust/Cargo.toml").exists() {
+        return "rust".to_string();
+    }
+
+    ".".to_string()
+}
+
+fn get_cargo_toml_path(rust_root: &str) -> String {
+    if rust_root == "." {
+        "./Cargo.toml".to_string()
+    } else {
+        format!("{}/Cargo.toml", rust_root)
+    }
+}
+
+fn get_crate_name_from_toml(cargo_toml_path: &str) -> Option<String> {
+    let content = fs::read_to_string(cargo_toml_path).ok()?;
+    let re = Regex::new(r#"(?m)^name\s*=\s*"([^"]+)""#).ok()?;
+    re.captures(&content).map(|c| c.get(1).unwrap().as_str().to_string())
+}
 
 fn get_arg(name: &str) -> Option<String> {
     let args: Vec<String> = env::args().collect();
@@ -88,7 +121,18 @@ fn main() {
 
     let mut release_notes = get_changelog_for_version(&version);
 
-    // Add crates.io link if provided
+    // Add crates.io and docs.rs badges
+    let rust_root = get_rust_root();
+    let cargo_toml = get_cargo_toml_path(&rust_root);
+    if let Some(crate_name) = get_crate_name_from_toml(&cargo_toml) {
+        let badges = format!(
+            "[![Crates.io](https://img.shields.io/crates/v/{}?label=crates.io)](https://crates.io/crates/{}/{}) [![Docs.rs](https://docs.rs/{}/badge.svg)](https://docs.rs/{}/{})",
+            crate_name, crate_name, version, crate_name, crate_name, version
+        );
+        release_notes = format!("{}\n\n{}", badges, release_notes);
+    }
+
+    // Add explicit crates.io link if provided (overrides auto-detected)
     if let Some(url) = crates_io_url {
         release_notes = format!("{}\n\n{}", url, release_notes);
     }

--- a/scripts/version-and-commit.rs
+++ b/scripts/version-and-commit.rs
@@ -12,7 +12,7 @@
 //! - Single-language: Cargo.toml and changelog.d/ in repository root
 //! - Multi-language: Cargo.toml and changelog.d/ in rust/ subfolder
 //!
-//! Usage: rust-script scripts/version-and-commit.rs --bump-type <major|minor|patch> [--description <desc>] [--rust-root <path>]
+//! Usage: rust-script scripts/version-and-commit.rs --bump-type <major|minor|patch> [--description <desc>] [--rust-root <path>] [--tag-prefix <prefix>]
 //!
 //! ```cargo
 //! [dependencies]
@@ -297,6 +297,7 @@ fn main() {
     }
 
     let description = get_arg("description");
+    let tag_prefix = get_arg("tag-prefix").unwrap_or_else(|| "v".to_string());
     let rust_root = get_rust_root();
     let cargo_toml = get_cargo_toml_path(&rust_root);
     let changelog_dir = get_changelog_dir(&rust_root);
@@ -364,8 +365,8 @@ fn main() {
 
     // Commit changes
     let commit_msg = match &description {
-        Some(desc) => format!("chore: release v{}\n\n{}", new_version, desc),
-        None => format!("chore: release v{}", new_version),
+        Some(desc) => format!("chore: release {}{}\n\n{}", tag_prefix, new_version, desc),
+        None => format!("chore: release {}{}", tag_prefix, new_version),
     };
 
     if let Err(e) = exec("git", &["commit", "-m", &commit_msg]) {
@@ -375,16 +376,17 @@ fn main() {
     println!("Committed version {}", new_version);
 
     // Create tag
+    let tag_name = format!("{}{}", tag_prefix, new_version);
     let tag_msg = match &description {
-        Some(desc) => format!("Release v{}\n\n{}", new_version, desc),
-        None => format!("Release v{}", new_version),
+        Some(desc) => format!("Release {}\n\n{}", tag_name, desc),
+        None => format!("Release {}", tag_name),
     };
 
-    if let Err(e) = exec("git", &["tag", "-a", &format!("v{}", new_version), "-m", &tag_msg]) {
+    if let Err(e) = exec("git", &["tag", "-a", &tag_name, "-m", &tag_msg]) {
         eprintln!("Error creating tag: {}", e);
         exit(1);
     }
-    println!("Created tag v{}", new_version);
+    println!("Created tag {}", tag_name);
 
     // Push changes and tag
     if let Err(e) = exec("git", &["push"]) {

--- a/scripts/version-and-commit.rs
+++ b/scripts/version-and-commit.rs
@@ -2,6 +2,12 @@
 //! Bump version in Cargo.toml and commit changes
 //! Used by the CI/CD pipeline for releases
 //!
+//! IMPORTANT: This script checks crates.io (the source of truth for Rust packages),
+//! NOT git tags. This is critical because:
+//! - Git tags can exist without the package being published
+//! - GitHub releases create tags but don't publish to crates.io
+//! - Only crates.io publication means users can actually install the package
+//!
 //! Supports both single-language and multi-language repository structures:
 //! - Single-language: Cargo.toml and changelog.d/ in repository root
 //! - Multi-language: Cargo.toml and changelog.d/ in rust/ subfolder
@@ -12,6 +18,9 @@
 //! [dependencies]
 //! regex = "1"
 //! chrono = "0.4"
+//! ureq = "2"
+//! serde = { version = "1", features = ["derive"] }
+//! serde_json = "1"
 //! ```
 
 use std::env;
@@ -21,6 +30,7 @@ use std::path::Path;
 use std::process::{Command, exit};
 use regex::Regex;
 use chrono::Utc;
+use serde::Deserialize;
 
 fn get_arg(name: &str) -> Option<String> {
     let args: Vec<String> = env::args().collect();
@@ -149,8 +159,53 @@ fn update_cargo_toml(cargo_toml_path: &str, new_version: &str) -> Result<(), Str
     Ok(())
 }
 
-fn check_tag_exists(version: &str) -> bool {
-    exec_check("git", &["rev-parse", &format!("v{}", version)])
+#[derive(Deserialize)]
+struct CratesIoVersion {
+    version: Option<CratesIoVersionInfo>,
+}
+
+#[derive(Deserialize)]
+struct CratesIoVersionInfo {
+    #[allow(dead_code)]
+    num: String,
+}
+
+fn get_crate_name(cargo_toml_path: &str) -> Result<String, String> {
+    let content = fs::read_to_string(cargo_toml_path)
+        .map_err(|e| format!("Failed to read {}: {}", cargo_toml_path, e))?;
+
+    let re = Regex::new(r#"(?m)^name\s*=\s*"([^"]+)""#).unwrap();
+
+    if let Some(caps) = re.captures(&content) {
+        Ok(caps.get(1).unwrap().as_str().to_string())
+    } else {
+        Err(format!("Could not find name in {}", cargo_toml_path))
+    }
+}
+
+fn check_version_on_crates_io(crate_name: &str, version: &str) -> bool {
+    let url = format!("https://crates.io/api/v1/crates/{}/{}", crate_name, version);
+
+    match ureq::get(&url)
+        .set("User-Agent", "rust-script-version-and-commit")
+        .call()
+    {
+        Ok(response) => {
+            if response.status() == 200 {
+                if let Ok(body) = response.into_string() {
+                    if let Ok(data) = serde_json::from_str::<CratesIoVersion>(&body) {
+                        return data.version.is_some();
+                    }
+                }
+            }
+            false
+        }
+        Err(ureq::Error::Status(404, _)) => false,
+        Err(e) => {
+            eprintln!("Warning: Could not check crates.io: {}", e);
+            false
+        }
+    }
 }
 
 fn strip_frontmatter(content: &str) -> String {
@@ -270,9 +325,17 @@ fn main() {
 
     let new_version = current.bump(&bump_type);
 
-    // Check if this version was already released
-    if check_tag_exists(&new_version) {
-        println!("Tag v{} already exists", new_version);
+    // Check if this version was already published to crates.io (the source of truth)
+    let crate_name = match get_crate_name(&cargo_toml) {
+        Ok(name) => name,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
+    };
+
+    if check_version_on_crates_io(&crate_name, &new_version) {
+        println!("Version {} already published on crates.io", new_version);
         set_output("already_released", "true");
         set_output("new_version", &new_version);
         return;


### PR DESCRIPTION
## Summary

- **Fixed** `version-and-commit.rs` to check crates.io API instead of git tags (`git rev-parse`) for determining if a version is already released. Git tags are not the source of truth for Rust package publication — tags can exist without the package being on crates.io (e.g., failed publish, GitHub-only releases, manual tag creation).
- **Added** `--tag-prefix` support to `version-and-commit.rs` for multi-language repository compatibility (aligns with `create-github-release.rs` which already supports this).
- **Added** crates.io and docs.rs badges to README.md (best practice from reference repos).
- **Enhanced** `create-github-release.rs` to auto-inject crates.io and docs.rs badges into GitHub release notes.
- **Added** documentation deployment job to CI/CD pipeline (deploys API docs to GitHub Pages after release).
- **Added** case study documentation in `docs/case-studies/issue-25/` with root cause analysis, timeline, and lessons learned.
- **Added** test script (`experiments/test-crates-io-check.rs`) validating the crates.io API check.
- **Fixed** `Cargo.lock` to sync with `Cargo.toml` version 0.2.0.

Fixes #25

## Root Cause

`version-and-commit.rs` line 152-154 used `check_tag_exists()` → `git rev-parse v{version}` to determine if a version was "already released". This is incorrect because git tags can exist without the crate being published to crates.io (GitHub releases create tags, failed publishes leave stale tags, etc.). The fix replaces this with `check_version_on_crates_io()` which queries the crates.io API — the same approach already used in `check-release-needed.rs`.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features` passes
- [x] `cargo test --all-features --verbose` passes (22 tests)
- [x] `experiments/test-crates-io-check.rs` validates crates.io API check against known published/unpublished versions
- [x] CI pipeline passes (all jobs green on all platforms: ubuntu, macos, windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)