### PR TITLE
fix: resolve CARGO_TOKEN fallback, push retry, and mono-repo support (#32, #31)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,8 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
   # Support both CARGO_REGISTRY_TOKEN (cargo's native env var) and CARGO_TOKEN (for backwards compatibility)
-  CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
+  CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
+  CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
 
 jobs:
   # === DETECT CHANGES - determines which jobs should run ===
@@ -336,6 +337,7 @@ jobs:
         if: steps.check.outputs.should_release == 'true'
         id: publish-crate
         env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
           CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
         run: rust-script scripts/publish-crate.rs
 
@@ -399,6 +401,7 @@ jobs:
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         id: publish-crate
         env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
           CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
         run: rust-script scripts/publish-crate.rs
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: [detect-changes, changelog]
     # Run if: push event, OR changelog succeeded, OR changelog was skipped (docs-only PR)
-    if: always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.changelog.result == 'success' || needs.changelog.result == 'skipped')
+    if: always() && !cancelled() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.changelog.result == 'success' || needs.changelog.result == 'skipped')
     strategy:
       fail-fast: false
       matrix:

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-13T09:27:53.380Z for PR creation at branch issue-32-47464d9719da for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/32

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-13T09:27:53.380Z for PR creation at branch issue-32-47464d9719da for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/32

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "example-sum-package-name"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "lino-arguments",

--- a/changelog.d/20260413_fix_cargo_token_fallback.md
+++ b/changelog.d/20260413_fix_cargo_token_fallback.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Fix publish steps overriding workflow-level CARGO_TOKEN fallback, breaking CARGO_REGISTRY_TOKEN-only configurations (#32)
+- Fix non-fast-forward push failures in multi-workflow repos by adding fetch/rebase and push retry logic (#31)
+- Add mono-repo path support to check-changelog-fragment.rs, check-version-modification.rs, and create-changelog-fragment.rs
+- Add `!cancelled()` guard to test job condition to respect workflow cancellation

--- a/docs/case-studies/issue-32/README.md
+++ b/docs/case-studies/issue-32/README.md
@@ -1,0 +1,97 @@
+# Case Study: Issue #32 — Publish Steps Override Workflow-Level CARGO_TOKEN Fallback
+
+## Summary
+
+The CI/CD pipeline's publish steps used a step-level `env` block that overrode the workflow-level `CARGO_TOKEN` fallback chain, breaking repositories that only configure `CARGO_REGISTRY_TOKEN` as a secret. Additionally, the `version-and-commit.rs` script lacked push retry logic, causing failures in multi-workflow repositories with concurrent release jobs.
+
+## Timeline of Events
+
+1. **Origin**: The issue was first observed in [link-assistant/web-capture#46](https://github.com/link-assistant/web-capture/issues/46), where `CARGO_REGISTRY_TOKEN` was not set in the publish step, causing the publish to skip silently.
+
+2. **Discovery**: Investigation revealed that the workflow-level `env` block correctly defined a fallback chain (`${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}`), but the per-step `env` blocks in both `auto-release` and `manual-release` jobs overrode this with only `${{ secrets.CARGO_TOKEN }}`, which would be empty if only `CARGO_REGISTRY_TOKEN` was configured.
+
+3. **Related issue #31**: In [link-assistant/agent](https://github.com/link-assistant/agent), the Rust auto-release job failed with `non-fast-forward` errors when a JS release job pushed to `main` first. The `version-and-commit.rs` script did a single `git push` with no retry or rebase logic.
+
+4. **Scope expansion**: Comparison with reference repos (browser-commander, lino-arguments, trees-rs, Numbers) revealed additional gaps in mono-repo path support across several scripts.
+
+## Root Cause Analysis
+
+### Problem 1: CARGO_TOKEN Fallback (Issue #32)
+
+**Root cause**: GitHub Actions step-level `env` blocks override workflow-level `env` for the same variable name. The publish steps set:
+
+```yaml
+env:
+  CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+```
+
+This overrides the workflow-level `CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}`, making `CARGO_TOKEN` empty when only `CARGO_REGISTRY_TOKEN` is configured as a repository secret.
+
+**Mitigating factor**: The `publish-crate.rs` script checks both `CARGO_REGISTRY_TOKEN` and `CARGO_TOKEN` environment variables (in that order), so publishing still worked because `CARGO_REGISTRY_TOKEN` was inherited from the workflow-level env. However, this was fragile and misleading.
+
+**Fix**: Set both `CARGO_REGISTRY_TOKEN` (with fallback) and `CARGO_TOKEN` at both workflow and step levels:
+
+```yaml
+env:
+  CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
+  CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+```
+
+### Problem 2: Non-Fast-Forward Push (Issue #31)
+
+**Root cause**: The `version-and-commit.rs` script performed a single `git push` without first rebasing on the remote branch. In multi-workflow repositories where multiple release jobs can push to `main` concurrently, the first push succeeds but subsequent pushes fail with `non-fast-forward` errors.
+
+**Fix**: Added pre-commit `git fetch` + `rebase` and post-commit push retry (3 attempts) with `git pull --rebase` between failures.
+
+### Problem 3: Inconsistent Mono-Repo Support
+
+**Root cause**: Several scripts (`check-changelog-fragment.rs`, `check-version-modification.rs`, `create-changelog-fragment.rs`) hardcoded paths like `Cargo.toml`, `changelog.d/`, `src/`, `tests/` without considering the `rust/` subdirectory prefix used in multi-language repositories.
+
+**Fix**: Added `get_rust_root()` detection (checks `RUST_ROOT` env var, then auto-detects `./Cargo.toml` vs `./rust/Cargo.toml`) to all affected scripts.
+
+## Requirements from Issue
+
+| # | Requirement | Status |
+|---|---|---|
+| 1 | Fix CARGO_TOKEN fallback in publish steps | Done |
+| 2 | Support CARGO_REGISTRY_TOKEN-only configurations | Done |
+| 3 | Fix non-fast-forward push in multi-workflow repos (#31) | Done |
+| 4 | Compare CI/CD with reference repos for best practices | Done |
+| 5 | Ensure mono-repo support across all scripts | Done |
+| 6 | Add `!cancelled()` guard to test job | Done |
+| 7 | Create case study documentation | Done |
+
+## Affected Repositories
+
+The same CARGO_TOKEN fallback issue exists in:
+- `link-foundation/browser-commander` (`.github/workflows/rust.yml`)
+- `link-foundation/lino-arguments` (`.github/workflows/rust.yml`)
+- `linksplatform/Numbers` (`.github/workflows/rust.yml`)
+
+Since these are derived from this template, fixing it here allows downstream repos to adopt the fix.
+
+## Reference Comparison Results
+
+A full comparison of CI/CD files was performed against 4 reference repos. Key findings:
+
+### Our template is ahead of all references in:
+- Push retry logic (3 attempts with pull-rebase)
+- Pre-commit fetch/rebase for concurrent workflows
+- Dual CARGO_REGISTRY_TOKEN + CARGO_TOKEN env setup
+- Code coverage with cargo-llvm-cov + Codecov
+- Automated badges in GitHub release notes
+- Template-aware skips (example-sum-package-name guard)
+- Configurable tag prefix and release label
+- Updated GitHub Actions versions (v5/v6/v8)
+- `--all-features` in cargo doc
+
+### Adopted from references:
+- `!cancelled()` guard in test job condition (from lino-arguments, browser-commander)
+
+## Files Changed
+
+- `.github/workflows/release.yml` — CARGO_REGISTRY_TOKEN fallback, `!cancelled()` guard
+- `scripts/version-and-commit.rs` — fetch/rebase + push retry logic
+- `scripts/check-changelog-fragment.rs` — mono-repo path support
+- `scripts/check-version-modification.rs` — mono-repo path support
+- `scripts/create-changelog-fragment.rs` — mono-repo path support

--- a/scripts/check-changelog-fragment.rs
+++ b/scripts/check-changelog-fragment.rs
@@ -21,6 +21,7 @@
 //! ```
 
 use std::env;
+use std::path::Path;
 use std::process::{Command, exit};
 use regex::Regex;
 
@@ -42,6 +43,24 @@ fn exec(command: &str, args: &[&str]) -> String {
     }
 }
 
+fn get_rust_root() -> String {
+    if let Ok(root) = env::var("RUST_ROOT") {
+        if !root.is_empty() {
+            return root;
+        }
+    }
+
+    if Path::new("./Cargo.toml").exists() {
+        return ".".to_string();
+    }
+
+    if Path::new("./rust/Cargo.toml").exists() {
+        return "rust".to_string();
+    }
+
+    ".".to_string()
+}
+
 fn get_changed_files() -> Vec<String> {
     let base_ref = env::var("GITHUB_BASE_REF").unwrap_or_else(|_| "main".to_string());
     eprintln!("Comparing against origin/{}...HEAD", base_ref);
@@ -58,26 +77,34 @@ fn get_changed_files() -> Vec<String> {
     output.lines().filter(|s| !s.is_empty()).map(String::from).collect()
 }
 
-fn is_source_file(file_path: &str) -> bool {
+fn is_source_file(file_path: &str, rust_root: &str) -> bool {
+    let prefix = if rust_root == "." { String::new() } else { format!("{}/", rust_root) };
+
     let source_patterns = [
-        Regex::new(r"^src/").unwrap(),
-        Regex::new(r"^tests/").unwrap(),
-        Regex::new(r"^scripts/").unwrap(),
-        Regex::new(r"^Cargo\.toml$").unwrap(),
+        Regex::new(&format!(r"^{}src/", regex::escape(&prefix))).unwrap(),
+        Regex::new(&format!(r"^{}tests/", regex::escape(&prefix))).unwrap(),
+        Regex::new(&format!(r"^{}?scripts/", regex::escape(&prefix))).unwrap(),
+        Regex::new(&format!(r"^{}Cargo\.toml$", regex::escape(&prefix))).unwrap(),
     ];
 
     source_patterns.iter().any(|pattern| pattern.is_match(file_path))
 }
 
-fn is_changelog_fragment(file_path: &str) -> bool {
-    // Changelog fragments are .md files in changelog.d/ (excluding README.md)
-    file_path.starts_with("changelog.d/")
+fn is_changelog_fragment(file_path: &str, rust_root: &str) -> bool {
+    let changelog_dir = if rust_root == "." { "changelog.d/".to_string() } else { format!("{}/changelog.d/", rust_root) };
+
+    (file_path.starts_with(&changelog_dir) || file_path.starts_with("changelog.d/"))
         && file_path.ends_with(".md")
         && !file_path.ends_with("README.md")
 }
 
 fn main() {
     println!("Checking for changelog fragment in PR diff...\n");
+
+    let rust_root = get_rust_root();
+    if rust_root != "." {
+        println!("Detected multi-language repository (Rust root: {})", rust_root);
+    }
 
     let changed_files = get_changed_files();
 
@@ -93,7 +120,7 @@ fn main() {
     println!();
 
     // Count source files changed
-    let source_changes: Vec<&String> = changed_files.iter().filter(|f| is_source_file(f)).collect();
+    let source_changes: Vec<&String> = changed_files.iter().filter(|f| is_source_file(f, &rust_root)).collect();
     let source_changed_count = source_changes.len();
 
     println!("Source files changed: {}", source_changed_count);
@@ -107,7 +134,7 @@ fn main() {
     // Count changelog fragments added in this PR
     let fragments_added: Vec<&String> = changed_files
         .iter()
-        .filter(|f| is_changelog_fragment(f))
+        .filter(|f| is_changelog_fragment(f, &rust_root))
         .collect();
     let fragment_added_count = fragments_added.len();
 

--- a/scripts/check-version-modification.rs
+++ b/scripts/check-version-modification.rs
@@ -27,6 +27,7 @@
 //! ```
 
 use std::env;
+use std::path::Path;
 use std::process::{Command, exit};
 use regex::Regex;
 
@@ -68,7 +69,33 @@ fn should_skip_version_check() -> bool {
     false
 }
 
-fn get_cargo_toml_diff() -> String {
+fn get_rust_root() -> String {
+    if let Ok(root) = env::var("RUST_ROOT") {
+        if !root.is_empty() {
+            return root;
+        }
+    }
+
+    if Path::new("./Cargo.toml").exists() {
+        return ".".to_string();
+    }
+
+    if Path::new("./rust/Cargo.toml").exists() {
+        return "rust".to_string();
+    }
+
+    ".".to_string()
+}
+
+fn get_cargo_toml_path(rust_root: &str) -> String {
+    if rust_root == "." {
+        "Cargo.toml".to_string()
+    } else {
+        format!("{}/Cargo.toml", rust_root)
+    }
+}
+
+fn get_cargo_toml_diff(cargo_toml_path: &str) -> String {
     let base_ref = env::var("GITHUB_BASE_REF").unwrap_or_else(|_| "main".to_string());
 
     // Ensure we have the base branch
@@ -77,7 +104,7 @@ fn get_cargo_toml_diff() -> String {
     // Get the diff for Cargo.toml
     exec(
         "git",
-        &["diff", &format!("origin/{}...HEAD", base_ref), "--", "Cargo.toml"],
+        &["diff", &format!("origin/{}...HEAD", base_ref), "--", cargo_toml_path],
     )
 }
 
@@ -108,7 +135,9 @@ fn main() {
     }
 
     // Get and check the diff
-    let diff = get_cargo_toml_diff();
+    let rust_root = get_rust_root();
+    let cargo_toml_path = get_cargo_toml_path(&rust_root);
+    let diff = get_cargo_toml_diff(&cargo_toml_path);
 
     if diff.is_empty() {
         println!("No changes to Cargo.toml detected.");

--- a/scripts/create-changelog-fragment.rs
+++ b/scripts/create-changelog-fragment.rs
@@ -29,6 +29,36 @@ fn get_arg(name: &str) -> Option<String> {
     env::var(&env_name).ok().filter(|s| !s.is_empty())
 }
 
+fn get_rust_root() -> String {
+    if let Some(root) = get_arg("rust-root") {
+        return root;
+    }
+
+    if let Ok(root) = env::var("RUST_ROOT") {
+        if !root.is_empty() {
+            return root;
+        }
+    }
+
+    if Path::new("./Cargo.toml").exists() {
+        return ".".to_string();
+    }
+
+    if Path::new("./rust/Cargo.toml").exists() {
+        return "rust".to_string();
+    }
+
+    ".".to_string()
+}
+
+fn get_changelog_dir(rust_root: &str) -> String {
+    if rust_root == "." {
+        "changelog.d".to_string()
+    } else {
+        format!("{}/changelog.d", rust_root)
+    }
+}
+
 fn get_category(bump_type: &str) -> &'static str {
     match bump_type {
         "major" => "### Breaking Changes",
@@ -52,7 +82,8 @@ fn main() {
         exit(1);
     }
 
-    let changelog_dir = "changelog.d";
+    let rust_root = get_rust_root();
+    let changelog_dir = get_changelog_dir(&rust_root);
     let timestamp = generate_timestamp();
     let fragment_file = format!("{}/{}-manual-{}.md", changelog_dir, timestamp, bump_type);
 
@@ -66,8 +97,8 @@ fn main() {
         bump_type, category, description_text
     );
 
-    // Ensure changelog.d directory exists
-    let dir_path = Path::new(changelog_dir);
+    // Ensure changelog directory exists
+    let dir_path = Path::new(&changelog_dir);
     if !dir_path.exists() {
         if let Err(e) = fs::create_dir_all(dir_path) {
             eprintln!("Error creating directory {}: {}", changelog_dir, e);

--- a/scripts/version-and-commit.rs
+++ b/scripts/version-and-commit.rs
@@ -467,6 +467,23 @@ fn main() {
         return;
     }
 
+    // Fetch latest remote state before committing (supports concurrent release workflows)
+    let current_branch = exec("git", &["rev-parse", "--abbrev-ref", "HEAD"]).unwrap_or_else(|_| "main".to_string());
+    if let Err(e) = exec("git", &["fetch", "origin", &current_branch]) {
+        eprintln!("Warning: Could not fetch origin/{}: {}", current_branch, e);
+    } else {
+        let local = exec("git", &["rev-parse", "HEAD"]).unwrap_or_default();
+        let remote = exec("git", &["rev-parse", &format!("origin/{}", current_branch)]).unwrap_or_default();
+        if !local.is_empty() && !remote.is_empty() && local != remote {
+            println!("Local branch is behind remote, rebasing...");
+            if let Err(e) = exec("git", &["rebase", &format!("origin/{}", current_branch)]) {
+                eprintln!("Error rebasing onto origin/{}: {}", current_branch, e);
+                let _ = exec("git", &["rebase", "--abort"]);
+                exit(1);
+            }
+        }
+    }
+
     // Commit changes
     let label_suffix = release_label.as_ref().map(|l| format!(" ({})", l)).unwrap_or_default();
     let commit_msg = match &description {
@@ -493,10 +510,26 @@ fn main() {
     }
     println!("Created tag {}", tag_name);
 
-    // Push changes and tag
-    if let Err(e) = exec("git", &["push"]) {
-        eprintln!("Error pushing: {}", e);
-        exit(1);
+    // Push changes and tag with retry (handles concurrent pushes in multi-workflow repos)
+    let max_push_attempts = 3;
+    for attempt in 1..=max_push_attempts {
+        match exec("git", &["push"]) {
+            Ok(_) => break,
+            Err(e) => {
+                if attempt < max_push_attempts {
+                    eprintln!("Push failed (attempt {}/{}): {}", attempt, max_push_attempts, e);
+                    eprintln!("Pulling with rebase and retrying...");
+                    if let Err(rebase_err) = exec("git", &["pull", "--rebase", "origin", &current_branch]) {
+                        eprintln!("Error during pull --rebase: {}", rebase_err);
+                        let _ = exec("git", &["rebase", "--abort"]);
+                        exit(1);
+                    }
+                } else {
+                    eprintln!("Error pushing after {} attempts: {}", max_push_attempts, e);
+                    exit(1);
+                }
+            }
+        }
     }
 
     if let Err(e) = exec("git", &["push", "--tags"]) {


### PR DESCRIPTION
## Summary

- **Fix #32**: Update publish step env blocks to include `CARGO_REGISTRY_TOKEN` with the same fallback chain as workflow-level env, ensuring publishing works when only `CARGO_REGISTRY_TOKEN` is configured as a secret
- **Fix #31**: Add fetch/rebase before commit and push retry (3 attempts with `pull --rebase`) in `version-and-commit.rs`, preventing non-fast-forward failures in multi-workflow repos
- **Best practices**: Add `!cancelled()` guard to test job condition (adopted from reference repos), add mono-repo path support to 3 scripts that were missing it
- **Case study**: Full root cause analysis with timeline, requirements checklist, and reference repo comparison in `docs/case-studies/issue-32/`

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Set both `CARGO_REGISTRY_TOKEN` and `CARGO_TOKEN` at workflow and step levels; add `!cancelled()` to test job |
| `scripts/version-and-commit.rs` | Add pre-commit fetch/rebase + 3-attempt push retry with `pull --rebase` |
| `scripts/check-changelog-fragment.rs` | Add `get_rust_root()` for mono-repo path detection |
| `scripts/check-version-modification.rs` | Add `get_rust_root()` for mono-repo Cargo.toml path |
| `scripts/create-changelog-fragment.rs` | Add `get_rust_root()` for mono-repo changelog.d path |
| `docs/case-studies/issue-32/README.md` | Root cause analysis, timeline, comparison results |
| `changelog.d/20260413_fix_cargo_token_fallback.md` | Changelog fragment |

## Root Cause

GitHub Actions step-level `env` blocks override workflow-level `env` for the same variable name. The publish steps set `CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}` which overrode the workflow-level fallback `CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}`, making it empty when only `CARGO_REGISTRY_TOKEN` was configured.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features` passes
- [x] `cargo test --all-features` passes (13 tests)
- [x] Main branch merged into PR branch
- [ ] CI pipeline passes on PR
- [ ] Verify `CARGO_REGISTRY_TOKEN` is correctly populated in publish steps when only one secret is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)