### PR TITLE
fix: use per-commit diff instead of full PR diff for change detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,8 +67,6 @@ jobs:
         id: changes
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: rust-script scripts/detect-code-changes.rs
 
   # === CHANGELOG CHECK - only runs on PRs with code changes ===

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-14T10:37:57.874Z for PR creation at branch issue-34-509f4c910b4b for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/34

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-14T10:37:57.874Z for PR creation at branch issue-34-509f4c910b4b for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/34

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "example-sum-package-name"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "lino-arguments",

--- a/changelog.d/20260414_fix_per_commit_diff.md
+++ b/changelog.d/20260414_fix_per_commit_diff.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Change detection script now uses per-commit diff instead of full PR diff, so commits touching only non-code files correctly skip CI jobs even when earlier commits in the same PR changed code files

--- a/docs/case-studies/issue-34/README.md
+++ b/docs/case-studies/issue-34/README.md
@@ -84,9 +84,25 @@ The `GITHUB_BASE_SHA` and `GITHUB_HEAD_SHA` environment variables were removed f
 | Use `GITHUB_BASE_SHA`/`GITHUB_HEAD_SHA` with commit limiting | Uses official GitHub API values | Still gives full PR diff; doesn't solve the core problem | No |
 | GitHub Actions `paths:` filters | Built-in, no script needed | Evaluates full PR diff; same fundamental problem | No |
 
+## Additional Context: GitHub Actions Merge Commit Behavior
+
+GitHub Actions creates two special refs for every pull request:
+- `refs/pull/NUMBER/head` — the HEAD of the PR branch
+- `refs/pull/NUMBER/merge` — a synthetic merge commit previewing the merge into the target branch
+
+When using the `pull_request` trigger, `@actions/checkout` checks out `refs/pull/NUMBER/merge` (the synthetic merge commit). This means:
+- `HEAD` is the merge commit (has 2 parents)
+- `HEAD^` (first parent) is the base branch tip
+- `HEAD^2` (second parent) is the actual PR head commit
+
+This is documented in the [GitHub community discussion on base.sha behavior](https://github.com/orgs/community/discussions/59677) and the [Frontside deep dive into pull_request](https://frontside.com/blog/2020-05-26-github-actions-pull_request/). The [actions/checkout issue #426](https://github.com/actions/checkout/issues/426) also discusses the distinction between checking out the merge commit vs the HEAD commit.
+
 ## References
 
 - [link-assistant/web-capture#50](https://github.com/link-assistant/web-capture/issues/50) — Original issue
 - [link-assistant/web-capture#51](https://github.com/link-assistant/web-capture/pull/51) — Reference implementation (JS)
 - [link-foundation/js-ai-driven-development-pipeline-template#31](https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/31) — Same issue on JS template
 - [GitHub Actions: Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) — Documentation on synthetic merge commits
+- [GitHub community discussion: base.sha update behavior](https://github.com/orgs/community/discussions/59677) — Explains how `github.event.pull_request.base.sha` works
+- [Frontside: GitHub Actions pull_request deep dive](https://frontside.com/blog/2020-05-26-github-actions-pull_request/) — Explains synthetic merge commit structure
+- [actions/checkout#426: Merge commit vs HEAD commit](https://github.com/actions/checkout/issues/426) — Discussion on checkout behavior for PRs

--- a/docs/case-studies/issue-34/README.md
+++ b/docs/case-studies/issue-34/README.md
@@ -84,6 +84,22 @@ The `GITHUB_BASE_SHA` and `GITHUB_HEAD_SHA` environment variables were removed f
 | Use `GITHUB_BASE_SHA`/`GITHUB_HEAD_SHA` with commit limiting | Uses official GitHub API values | Still gives full PR diff; doesn't solve the core problem | No |
 | GitHub Actions `paths:` filters | Built-in, no script needed | Evaluates full PR diff; same fundamental problem | No |
 
+## CI Verification
+
+The fix was verified in CI run [#24394764654](https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/actions/runs/24394764654). The last commit (removing `.gitkeep`) correctly triggered only the per-commit diff:
+
+```
+Merge commit detected (pull_request event)
+Comparing HEAD^2^ to HEAD^2 (per-commit diff of PR head)
+Changed files:
+  .gitkeep
+rs-changed=false
+toml-changed=false
+any-code-changed=false
+```
+
+As a result, Lint, Code Coverage, and Changelog Fragment Check were all correctly **skipped** — they would have been triggered under the old full-PR-diff behavior because earlier commits in the PR modified `.rs` and `.yml` files.
+
 ## Additional Context: GitHub Actions Merge Commit Behavior
 
 GitHub Actions creates two special refs for every pull request:

--- a/docs/case-studies/issue-34/README.md
+++ b/docs/case-studies/issue-34/README.md
@@ -1,0 +1,92 @@
+# Case Study: Issue #34 — detect-code-changes Uses Full PR Diff Instead of Per-Commit Diff
+
+## Summary
+
+The `detect-code-changes.rs` script compared the full PR diff (base SHA to head SHA) instead of evaluating each commit individually. This caused a commit that only modified non-code files (e.g., `.gitkeep`, `README.md`) to trigger all CI jobs if any earlier commit in the same PR touched code files.
+
+## Timeline of Events
+
+1. **Origin**: The issue was first observed in [link-assistant/web-capture PR #49](https://github.com/link-assistant/web-capture/pull/49), where commit `0e9b6e8c` only modified `.gitkeep` but triggered all 8 CI jobs because the PR as a whole contained code changes.
+
+2. **Root cause identified**: GitHub Actions checks out a **synthetic merge commit** for `pull_request` events:
+   - `HEAD` = synthetic merge commit
+   - `HEAD^` = base branch (first parent)
+   - `HEAD^2` = actual PR head commit (second parent)
+
+   Using `git diff HEAD^ HEAD` or `git diff base_sha head_sha` gives the **full PR diff**, not the per-commit diff. This is the same fundamental problem as GitHub Actions' `paths:` filters.
+
+3. **Fix developed and verified**: The fix was first implemented and CI-verified in [link-assistant/web-capture PR #51](https://github.com/link-assistant/web-capture/pull/51) using a JavaScript implementation (`detect-code-changes.mjs`).
+
+4. **Cross-repo filing**: The same issue was filed on both template repos:
+   - Rust template: [link-foundation/rust-ai-driven-development-pipeline-template#34](https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/34)
+   - JS template: [link-foundation/js-ai-driven-development-pipeline-template#31](https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/31)
+
+## Root Cause Analysis
+
+### Problem: Full PR Diff Instead of Per-Commit Diff
+
+**Root cause**: The `get_changed_files()` function in `detect-code-changes.rs` used `GITHUB_BASE_SHA` and `GITHUB_HEAD_SHA` environment variables to compute `git diff base_sha head_sha`, which returns all files changed across the entire PR — not just the latest commit.
+
+**Before (broken)**:
+```rust
+if event_name == "pull_request" {
+    let base_sha = env::var("GITHUB_BASE_SHA").ok();
+    let head_sha = env::var("GITHUB_HEAD_SHA").ok();
+    if let (Some(base), Some(head)) = (base_sha, head_sha) {
+        exec_silent("git", &["fetch", "origin", &base]);
+        let output = exec("git", &["diff", "--name-only", &base, &head]);
+        // This returns ALL files changed in the PR, not just the latest commit
+    }
+}
+```
+
+**Why `HEAD^..HEAD` also doesn't work for PRs**: GitHub Actions creates a synthetic merge commit for `pull_request` events. `HEAD^` is the base branch (first parent), so `git diff HEAD^ HEAD` also gives the full PR diff — the exact same problem.
+
+**After (fixed)**:
+```rust
+fn is_merge_commit() -> bool {
+    let output = exec("git", &["cat-file", "-p", "HEAD"]);
+    output.lines().filter(|line| line.starts_with("parent ")).count() > 1
+}
+
+fn get_changed_files() -> Vec<String> {
+    if is_merge_commit() {
+        // HEAD^2 = actual PR head, HEAD^2^ = its parent
+        // This gives the per-commit diff of the latest push
+        let output = exec("git", &["diff", "--name-only", "HEAD^2^", "HEAD^2"]);
+        // ...
+    }
+    // For push events: HEAD^ to HEAD (regular per-commit diff)
+}
+```
+
+**Key insight**: `HEAD^2` is the actual PR head commit (second parent of the merge commit). `HEAD^2^` is its parent. So `git diff HEAD^2^ HEAD^2` gives exactly the per-commit diff of the latest push to the PR.
+
+### Workflow Change
+
+The `GITHUB_BASE_SHA` and `GITHUB_HEAD_SHA` environment variables were removed from the workflow's detect-changes step since they are no longer needed — the script now uses git's commit graph directly.
+
+## Requirements from Issue
+
+| # | Requirement | Status |
+|---|---|---|
+| 1 | Use per-commit diff instead of full PR diff for change detection | Done |
+| 2 | Handle GitHub Actions synthetic merge commit correctly | Done |
+| 3 | Follow best practices from web-capture PR #51 | Done |
+| 4 | Create case study with root cause analysis | Done |
+| 5 | Create experiment scripts for testing | Done |
+
+## Possible Solutions Considered
+
+| Solution | Pros | Cons | Chosen? |
+|---|---|---|---|
+| Merge commit detection (`HEAD^2^..HEAD^2`) | Accurate per-commit diff; works without env vars; proven in web-capture CI | Requires understanding of git merge commit structure | Yes |
+| Use `GITHUB_BASE_SHA`/`GITHUB_HEAD_SHA` with commit limiting | Uses official GitHub API values | Still gives full PR diff; doesn't solve the core problem | No |
+| GitHub Actions `paths:` filters | Built-in, no script needed | Evaluates full PR diff; same fundamental problem | No |
+
+## References
+
+- [link-assistant/web-capture#50](https://github.com/link-assistant/web-capture/issues/50) — Original issue
+- [link-assistant/web-capture#51](https://github.com/link-assistant/web-capture/pull/51) — Reference implementation (JS)
+- [link-foundation/js-ai-driven-development-pipeline-template#31](https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/31) — Same issue on JS template
+- [GitHub Actions: Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) — Documentation on synthetic merge commits

--- a/experiments/test-detect-code-changes.sh
+++ b/experiments/test-detect-code-changes.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Test script for detect-code-changes.rs merge commit detection logic
+#
+# This script creates a temporary git repository with a synthetic merge
+# commit (similar to GitHub Actions' pull_request checkout) and verifies
+# that the detect-code-changes script correctly uses per-commit diff.
+#
+# Usage: bash experiments/test-detect-code-changes.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+echo "=== Test: detect-code-changes merge commit detection ==="
+echo "Temp dir: $TEMP_DIR"
+echo ""
+
+cd "$TEMP_DIR"
+git init -b main test-repo
+cd test-repo
+git config user.email "test@test.com"
+git config user.name "Test"
+
+# --- Setup: Create a main branch with initial files ---
+echo "fn main() {}" > main.rs
+echo "[package]" > Cargo.toml
+git add .
+git commit -m "Initial commit"
+
+# --- Create a PR branch with two commits ---
+git checkout -b pr-branch
+
+# Commit 1: touches code files
+echo "fn foo() {}" >> main.rs
+git add main.rs
+git commit -m "Add foo function"
+
+# Commit 2: touches only non-code files (like .gitkeep)
+touch .gitkeep
+git add .gitkeep
+git commit -m "Add .gitkeep only"
+
+PR_HEAD=$(git rev-parse HEAD)
+PR_HEAD_PARENT=$(git rev-parse HEAD^)
+
+# --- Go back to main and create a synthetic merge commit ---
+git checkout main
+git merge --no-ff pr-branch -m "Merge PR"
+
+echo ""
+echo "=== Git log ==="
+git log --oneline --graph --all
+echo ""
+
+echo "=== Merge commit verification ==="
+PARENT_COUNT=$(git cat-file -p HEAD | grep "^parent " | wc -l)
+echo "HEAD parent count: $PARENT_COUNT (expected: 2)"
+
+HEAD_SECOND_PARENT=$(git rev-parse HEAD^2)
+echo "HEAD^2 (PR head): $HEAD_SECOND_PARENT"
+echo "Expected PR head: $PR_HEAD"
+
+if [ "$HEAD_SECOND_PARENT" = "$PR_HEAD" ]; then
+  echo "PASS: HEAD^2 correctly points to PR head"
+else
+  echo "FAIL: HEAD^2 does not point to PR head"
+  exit 1
+fi
+
+echo ""
+echo "=== Diff comparisons ==="
+
+echo ""
+echo "--- Full PR diff (HEAD^ to HEAD) - WRONG for per-commit ---"
+git diff --name-only HEAD^ HEAD
+FULL_DIFF_COUNT=$(git diff --name-only HEAD^ HEAD | wc -l)
+echo "Files: $FULL_DIFF_COUNT (includes main.rs + .gitkeep = both commits)"
+
+echo ""
+echo "--- Per-commit diff (HEAD^2^ to HEAD^2) - CORRECT ---"
+git diff --name-only HEAD^2^ HEAD^2
+PERCOMMIT_DIFF_COUNT=$(git diff --name-only HEAD^2^ HEAD^2 | wc -l)
+echo "Files: $PERCOMMIT_DIFF_COUNT (should be only .gitkeep = last commit only)"
+
+echo ""
+echo "=== Assertions ==="
+
+if [ "$FULL_DIFF_COUNT" -eq 2 ]; then
+  echo "PASS: Full PR diff shows 2 files (both commits merged together)"
+else
+  echo "FAIL: Expected 2 files in full PR diff, got $FULL_DIFF_COUNT"
+  exit 1
+fi
+
+if [ "$PERCOMMIT_DIFF_COUNT" -eq 1 ]; then
+  echo "PASS: Per-commit diff shows 1 file (only latest commit)"
+else
+  echo "FAIL: Expected 1 file in per-commit diff, got $PERCOMMIT_DIFF_COUNT"
+  exit 1
+fi
+
+PERCOMMIT_FILE=$(git diff --name-only HEAD^2^ HEAD^2)
+if [ "$PERCOMMIT_FILE" = ".gitkeep" ]; then
+  echo "PASS: Per-commit diff correctly shows only .gitkeep"
+else
+  echo "FAIL: Expected .gitkeep, got $PERCOMMIT_FILE"
+  exit 1
+fi
+
+echo ""
+echo "=== All tests passed ==="

--- a/scripts/detect-code-changes.rs
+++ b/scripts/detect-code-changes.rs
@@ -1,11 +1,14 @@
 #!/usr/bin/env rust-script
 //! Detect code changes for CI/CD pipeline
 //!
-//! This script detects what types of files have changed between two commits
+//! This script detects what types of files have changed in the latest commit
 //! and outputs the results for use in GitHub Actions workflow conditions.
 //!
 //! Key behavior:
-//! - For PRs: compares PR head against base branch
+//! - For PRs: detects GitHub Actions' synthetic merge commit and uses
+//!   HEAD^2^..HEAD^2 to get the per-commit diff of the actual PR head,
+//!   so a commit touching only non-code files correctly skips CI jobs
+//!   even when earlier commits in the same PR touched code files.
 //! - For pushes: compares HEAD against HEAD^
 //! - Excludes certain folders and file types from "code changes" detection
 //!
@@ -20,8 +23,6 @@
 //!
 //! Environment variables (set by GitHub Actions):
 //!   - GITHUB_EVENT_NAME: 'pull_request' or 'push'
-//!   - GITHUB_BASE_SHA: Base commit SHA for PR
-//!   - GITHUB_HEAD_SHA: Head commit SHA for PR
 //!
 //! Outputs (written to GITHUB_OUTPUT):
 //!   - rs-changed: 'true' if any .rs files changed
@@ -60,14 +61,6 @@ fn exec(command: &str, args: &[&str]) -> String {
     }
 }
 
-fn exec_silent(command: &str, args: &[&str]) {
-    let _ = Command::new(command)
-        .args(args)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status();
-}
-
 fn set_output(name: &str, value: &str) {
     if let Ok(output_file) = env::var("GITHUB_OUTPUT") {
         if let Ok(mut file) = fs::OpenOptions::new().create(true).append(true).open(&output_file) {
@@ -77,32 +70,36 @@ fn set_output(name: &str, value: &str) {
     println!("{}={}", name, value);
 }
 
+fn is_merge_commit() -> bool {
+    let output = exec("git", &["cat-file", "-p", "HEAD"]);
+    output.lines().filter(|line| line.starts_with("parent ")).count() > 1
+}
+
 fn get_changed_files() -> Vec<String> {
-    let event_name = env::var("GITHUB_EVENT_NAME").unwrap_or_else(|_| "local".to_string());
-
-    if event_name == "pull_request" {
-        let base_sha = env::var("GITHUB_BASE_SHA").ok();
-        let head_sha = env::var("GITHUB_HEAD_SHA").ok();
-
-        if let (Some(base), Some(head)) = (base_sha, head_sha) {
-            println!("Comparing PR: {}...{}", base, head);
-
-            // Ensure we have the base commit
-            exec_silent("git", &["fetch", "origin", &base]);
-
-            let output = exec("git", &["diff", "--name-only", &base, &head]);
-            if !output.is_empty() {
-                return output.lines().filter(|s| !s.is_empty()).map(String::from).collect();
-            }
+    // GitHub Actions checks out a synthetic merge commit for pull_request
+    // events: HEAD is the merge commit, HEAD^ is the base branch, HEAD^2
+    // is the actual PR head. To get the per-commit diff (what the latest
+    // push actually changed), we compare HEAD^2^ to HEAD^2.
+    // For push events, HEAD is the real commit, so HEAD^ to HEAD works.
+    if is_merge_commit() {
+        println!("Merge commit detected (pull_request event)");
+        println!("Comparing HEAD^2^ to HEAD^2 (per-commit diff of PR head)");
+        let output = exec("git", &["diff", "--name-only", "HEAD^2^", "HEAD^2"]);
+        if !output.is_empty() {
+            return output.lines().filter(|s| !s.is_empty()).map(String::from).collect();
+        }
+        // Fallback: first commit in PR, compare base to PR head
+        println!("HEAD^2^ not available (first commit in PR), comparing HEAD^ to HEAD^2");
+        let output = exec("git", &["diff", "--name-only", "HEAD^", "HEAD^2"]);
+        if !output.is_empty() {
+            return output.lines().filter(|s| !s.is_empty()).map(String::from).collect();
         }
     }
 
-    // For push events or fallback
     println!("Comparing HEAD^ to HEAD");
     let output = exec("git", &["diff", "--name-only", "HEAD^", "HEAD"]);
 
     if output.is_empty() {
-        // If HEAD^ doesn't exist (first commit), list all files in HEAD
         println!("HEAD^ not available, listing all files in HEAD");
         let output = exec("git", &["ls-tree", "--name-only", "-r", "HEAD"]);
         return output.lines().filter(|s| !s.is_empty()).map(String::from).collect();


### PR DESCRIPTION
## Summary

- **Per-commit diff instead of full-PR diff**: The `detect-code-changes.rs` script now detects GitHub Actions' synthetic merge commit and uses `HEAD^2^..HEAD^2` to get only the files changed in the latest push, not the entire PR
- **Removes unused env vars**: `GITHUB_BASE_SHA` and `GITHUB_HEAD_SHA` are no longer needed in the workflow since the script uses git's commit graph directly
- **Case study and test**: Includes root cause analysis documentation and an experiment script that demonstrates the fix

Fixes #34

## Root Cause

Two related issues caused unnecessary CI runs:

1. **`GITHUB_BASE_SHA`/`GITHUB_HEAD_SHA` comparison** gives the full PR diff — all files changed across all commits, not just the latest push. A commit touching only `.gitkeep` would trigger all CI jobs because earlier commits in the same PR changed code files.

2. **GitHub Actions' synthetic merge commit** means `HEAD^..HEAD` also gives the full PR diff (since `HEAD^` is the base branch, not the previous PR commit).

**Evidence**: In [web-capture PR #49](https://github.com/link-assistant/web-capture/pull/49), commit `0e9b6e8c` only modified `.gitkeep` but triggered all 8 CI jobs.

## Solution

Detect the synthetic merge commit (HEAD with 2+ parents) and use `HEAD^2^..HEAD^2`:
- `HEAD` = synthetic merge commit
- `HEAD^2` = actual PR head commit (second parent)
- `HEAD^2^` = PR head's parent

So `git diff HEAD^2^ HEAD^2` = per-commit diff of the latest push.

For push events (non-merge commits), the regular `HEAD^..HEAD` is used.

### Changes

| File | Change |
|------|--------|
| `scripts/detect-code-changes.rs` | Replace `GITHUB_BASE_SHA`/`GITHUB_HEAD_SHA` comparison with merge commit detection and `HEAD^2^..HEAD^2` |
| `.github/workflows/release.yml` | Remove unused `GITHUB_BASE_SHA` and `GITHUB_HEAD_SHA` env vars from detect-changes step |
| `changelog.d/20260414_fix_per_commit_diff.md` | Changelog fragment for the fix |
| `docs/case-studies/issue-34/README.md` | Case study with timeline, root cause analysis, and solution comparison |
| `experiments/test-detect-code-changes.sh` | Test script that creates a synthetic merge commit and verifies per-commit vs full-PR diff |
| `Cargo.lock` | Sync version with Cargo.toml (0.5.0 → 0.6.0) |

## Test plan

- [x] Experiment script creates synthetic merge commit and verifies `HEAD^2^..HEAD^2` gives per-commit diff (only `.gitkeep`), while `HEAD^..HEAD` gives full PR diff (`.gitkeep` + `main.rs`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test --all-features` — all 10 tests pass
- [ ] CI: detect-changes job correctly uses per-commit diff on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)