### PR TITLE
fix: support release scripts on Cargo workspace repositories

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-15T14:41:01.082Z for PR creation at branch issue-36-5fb511c4472f for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/36

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-15T14:41:01.082Z for PR creation at branch issue-36-5fb511c4472f for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/36

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "example-sum-package-name"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "clap",
  "lino-arguments",

--- a/changelog.d/20260415_fix_workspace_release_scripts.md
+++ b/changelog.d/20260415_fix_workspace_release_scripts.md
@@ -1,0 +1,2 @@
+### Fixed
+- Make release scripts resolve the publishable crate manifest when the repository root uses a Cargo workspace manifest.

--- a/scripts/bump-version.rs
+++ b/scripts/bump-version.rs
@@ -14,9 +14,11 @@
 
 use std::env;
 use std::fs;
-use std::path::Path;
 use std::process::exit;
 use regex::Regex;
+
+#[path = "rust-paths.rs"]
+mod rust_paths;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum BumpType {
@@ -75,34 +77,6 @@ fn has_flag(name: &str) -> bool {
     args.contains(&flag)
 }
 
-fn get_rust_root() -> String {
-    if let Some(root) = get_arg("rust-root") {
-        return root;
-    }
-
-    // Auto-detect
-    if Path::new("./Cargo.toml").exists() {
-        eprintln!("Detected single-language repository (Cargo.toml in root)");
-        return ".".to_string();
-    }
-
-    if Path::new("./rust/Cargo.toml").exists() {
-        eprintln!("Detected multi-language repository (Cargo.toml in rust/)");
-        return "rust".to_string();
-    }
-
-    eprintln!("Error: Could not find Cargo.toml in expected locations");
-    exit(1);
-}
-
-fn get_cargo_toml_path(rust_root: &str) -> String {
-    if rust_root == "." {
-        "./Cargo.toml".to_string()
-    } else {
-        format!("{}/Cargo.toml", rust_root)
-    }
-}
-
 fn get_current_version(cargo_toml_path: &str) -> Result<Version, String> {
     let content = fs::read_to_string(cargo_toml_path)
         .map_err(|e| format!("Failed to read {}: {}", cargo_toml_path, e))?;
@@ -150,10 +124,23 @@ fn main() {
     };
 
     let dry_run = has_flag("dry-run");
-    let rust_root = get_rust_root();
-    let cargo_toml = get_cargo_toml_path(&rust_root);
+    let rust_root = match rust_paths::get_rust_root(None, true) {
+        Ok(root) => root,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
+    };
+    let cargo_toml = rust_paths::get_cargo_toml_path(&rust_root);
+    let package_manifest = match rust_paths::get_package_manifest_path(&cargo_toml) {
+        Ok(path) => path,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
+    };
 
-    let current = match get_current_version(&cargo_toml) {
+    let current = match get_current_version(package_manifest.to_string_lossy().as_ref()) {
         Ok(v) => v,
         Err(e) => {
             eprintln!("Error: {}", e);
@@ -169,10 +156,10 @@ fn main() {
     if dry_run {
         println!("Dry run - no changes made");
     } else {
-        if let Err(e) = update_cargo_toml(&cargo_toml, &new_version) {
+        if let Err(e) = update_cargo_toml(package_manifest.to_string_lossy().as_ref(), &new_version) {
             eprintln!("Error: {}", e);
             exit(1);
         }
-        println!("Updated {}", cargo_toml);
+        println!("Updated {}", package_manifest.display());
     }
 }

--- a/scripts/check-release-needed.rs
+++ b/scripts/check-release-needed.rs
@@ -35,10 +35,11 @@
 
 use std::env;
 use std::fs;
-use std::path::Path;
 use std::process::exit;
-use regex::Regex;
 use serde::Deserialize;
+
+#[path = "rust-paths.rs"]
+mod rust_paths;
 
 fn get_arg(name: &str) -> Option<String> {
     let args: Vec<String> = env::args().collect();
@@ -50,34 +51,6 @@ fn get_arg(name: &str) -> Option<String> {
 
     let env_name = name.to_uppercase().replace('-', "_");
     env::var(&env_name).ok().filter(|s| !s.is_empty())
-}
-
-fn get_rust_root() -> String {
-    if let Some(root) = get_arg("rust-root") {
-        eprintln!("Using explicitly configured Rust root: {}", root);
-        return root;
-    }
-
-    if Path::new("./Cargo.toml").exists() {
-        eprintln!("Detected single-language repository (Cargo.toml in root)");
-        return ".".to_string();
-    }
-
-    if Path::new("./rust/Cargo.toml").exists() {
-        eprintln!("Detected multi-language repository (Cargo.toml in rust/)");
-        return "rust".to_string();
-    }
-
-    eprintln!("Error: Could not find Cargo.toml in expected locations");
-    exit(1);
-}
-
-fn get_cargo_toml_path(rust_root: &str) -> String {
-    if rust_root == "." {
-        "./Cargo.toml".to_string()
-    } else {
-        format!("{}/Cargo.toml", rust_root)
-    }
 }
 
 fn set_output(key: &str, value: &str) {
@@ -95,32 +68,6 @@ fn set_output(key: &str, value: &str) {
         }
     }
     println!("Output: {}={}", key, value);
-}
-
-fn get_current_version(cargo_toml_path: &str) -> Result<String, String> {
-    let content = fs::read_to_string(cargo_toml_path)
-        .map_err(|e| format!("Failed to read {}: {}", cargo_toml_path, e))?;
-
-    let re = Regex::new(r#"(?m)^version\s*=\s*"([^"]+)""#).unwrap();
-
-    if let Some(caps) = re.captures(&content) {
-        Ok(caps.get(1).unwrap().as_str().to_string())
-    } else {
-        Err(format!("Could not find version in {}", cargo_toml_path))
-    }
-}
-
-fn get_crate_name(cargo_toml_path: &str) -> Result<String, String> {
-    let content = fs::read_to_string(cargo_toml_path)
-        .map_err(|e| format!("Failed to read {}: {}", cargo_toml_path, e))?;
-
-    let re = Regex::new(r#"(?m)^name\s*=\s*"([^"]+)""#).unwrap();
-
-    if let Some(caps) = re.captures(&content) {
-        Ok(caps.get(1).unwrap().as_str().to_string())
-    } else {
-        Err(format!("Could not find name in {}", cargo_toml_path))
-    }
 }
 
 #[derive(Deserialize)]
@@ -230,28 +177,35 @@ fn get_max_published_version(crate_name: &str) -> Option<String> {
 }
 
 fn main() {
-    let rust_root = get_rust_root();
-    let cargo_toml = get_cargo_toml_path(&rust_root);
+    let rust_root = match rust_paths::get_rust_root(None, true) {
+        Ok(root) => root,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
+    };
+    let cargo_toml = rust_paths::get_cargo_toml_path(&rust_root);
+    let package_manifest = match rust_paths::get_package_manifest_path(&cargo_toml) {
+        Ok(path) => path,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
+    };
 
     let has_fragments = env::var("HAS_FRAGMENTS")
         .map(|v| v == "true")
         .unwrap_or(false);
 
-    let crate_name = match get_crate_name(&cargo_toml) {
-        Ok(name) => name,
+    let package_info = match rust_paths::read_package_info(&package_manifest) {
+        Ok(info) => info,
         Err(e) => {
             eprintln!("Error: {}", e);
             exit(1);
         }
     };
-
-    let current_version = match get_current_version(&cargo_toml) {
-        Ok(version) => version,
-        Err(e) => {
-            eprintln!("Error: {}", e);
-            exit(1);
-        }
-    };
+    let crate_name = package_info.name;
+    let current_version = package_info.version;
 
     let max_published = get_max_published_version(&crate_name);
     if let Some(ref max_ver) = max_published {

--- a/scripts/get-version.rs
+++ b/scripts/get-version.rs
@@ -18,50 +18,11 @@
 //! regex = "1"
 //! ```
 
-use std::env;
 use std::fs;
-use std::path::Path;
 use std::process::exit;
-use regex::Regex;
 
-fn get_rust_root() -> String {
-    // Check CLI arguments
-    let args: Vec<String> = env::args().collect();
-    if let Some(idx) = args.iter().position(|a| a == "--rust-root") {
-        if let Some(root) = args.get(idx + 1) {
-            return root.clone();
-        }
-    }
-
-    // Check environment variable
-    if let Ok(root) = env::var("RUST_ROOT") {
-        if !root.is_empty() {
-            return root;
-        }
-    }
-
-    // Auto-detect
-    if Path::new("./Cargo.toml").exists() {
-        eprintln!("Detected single-language repository (Cargo.toml in root)");
-        return ".".to_string();
-    }
-
-    if Path::new("./rust/Cargo.toml").exists() {
-        eprintln!("Detected multi-language repository (Cargo.toml in rust/)");
-        return "rust".to_string();
-    }
-
-    eprintln!("Error: Could not find Cargo.toml in expected locations");
-    exit(1);
-}
-
-fn get_cargo_toml_path(rust_root: &str) -> String {
-    if rust_root == "." {
-        "./Cargo.toml".to_string()
-    } else {
-        format!("{}/Cargo.toml", rust_root)
-    }
-}
+#[path = "rust-paths.rs"]
+mod rust_paths;
 
 fn set_output(key: &str, value: &str) {
     if let Ok(output_file) = env::var("GITHUB_OUTPUT") {
@@ -80,27 +41,27 @@ fn set_output(key: &str, value: &str) {
     println!("Output: {}={}", key, value);
 }
 
-fn get_current_version(cargo_toml_path: &str) -> Result<String, String> {
-    let content = fs::read_to_string(cargo_toml_path)
-        .map_err(|e| format!("Failed to read {}: {}", cargo_toml_path, e))?;
-
-    let re = Regex::new(r#"(?m)^version\s*=\s*"([^"]+)""#).unwrap();
-
-    if let Some(caps) = re.captures(&content) {
-        Ok(caps.get(1).unwrap().as_str().to_string())
-    } else {
-        Err(format!("Could not find version in {}", cargo_toml_path))
-    }
-}
-
 fn main() {
-    let rust_root = get_rust_root();
-    let cargo_toml = get_cargo_toml_path(&rust_root);
+    let rust_root = match rust_paths::get_rust_root(None, true) {
+        Ok(root) => root,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
+    };
+    let cargo_toml = rust_paths::get_cargo_toml_path(&rust_root);
+    let package_manifest = match rust_paths::get_package_manifest_path(&cargo_toml) {
+        Ok(path) => path,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
+    };
 
-    match get_current_version(&cargo_toml) {
-        Ok(version) => {
-            println!("Current version: {}", version);
-            set_output("version", &version);
+    match rust_paths::read_package_info(&package_manifest) {
+        Ok(info) => {
+            println!("Current version: {}", info.version);
+            set_output("version", &info.version);
         }
         Err(e) => {
             eprintln!("Error: {}", e);

--- a/scripts/publish-crate.rs
+++ b/scripts/publish-crate.rs
@@ -25,9 +25,10 @@
 use std::env;
 use std::fs;
 use std::io::Write;
-use std::path::Path;
 use std::process::{Command, exit};
-use regex::Regex;
+
+#[path = "rust-paths.rs"]
+mod rust_paths;
 
 fn get_arg(name: &str) -> Option<String> {
     let args: Vec<String> = env::args().collect();
@@ -38,41 +39,6 @@ fn get_arg(name: &str) -> Option<String> {
     }
 
     None
-}
-
-fn get_rust_root() -> String {
-    if let Some(root) = get_arg("rust-root") {
-        eprintln!("Using explicitly configured Rust root: {}", root);
-        return root;
-    }
-
-    if let Ok(root) = env::var("RUST_ROOT") {
-        if !root.is_empty() {
-            eprintln!("Using environment configured Rust root: {}", root);
-            return root;
-        }
-    }
-
-    if Path::new("./Cargo.toml").exists() {
-        eprintln!("Detected single-language repository (Cargo.toml in root)");
-        return ".".to_string();
-    }
-
-    if Path::new("./rust/Cargo.toml").exists() {
-        eprintln!("Detected multi-language repository (Cargo.toml in rust/)");
-        return "rust".to_string();
-    }
-
-    eprintln!("Error: Could not find Cargo.toml in expected locations");
-    exit(1);
-}
-
-fn get_cargo_toml_path(rust_root: &str) -> String {
-    if rust_root == "." {
-        "./Cargo.toml".to_string()
-    } else {
-        format!("{}/Cargo.toml", rust_root)
-    }
 }
 
 fn needs_cd(rust_root: &str) -> bool {
@@ -88,42 +54,37 @@ fn set_output(key: &str, value: &str) {
     println!("Output: {}={}", key, value);
 }
 
-fn get_package_info(cargo_toml_path: &str) -> Result<(String, String), String> {
-    let content = fs::read_to_string(cargo_toml_path)
-        .map_err(|e| format!("Failed to read {}: {}", cargo_toml_path, e))?;
-
-    let name_re = Regex::new(r#"(?m)^name\s*=\s*"([^"]+)""#).unwrap();
-    let version_re = Regex::new(r#"(?m)^version\s*=\s*"([^"]+)""#).unwrap();
-
-    let name = name_re
-        .captures(&content)
-        .map(|c| c.get(1).unwrap().as_str().to_string())
-        .ok_or_else(|| format!("Could not find name in {}", cargo_toml_path))?;
-
-    let version = version_re
-        .captures(&content)
-        .map(|c| c.get(1).unwrap().as_str().to_string())
-        .ok_or_else(|| format!("Could not find version in {}", cargo_toml_path))?;
-
-    Ok((name, version))
-}
-
 fn main() {
-    let rust_root = get_rust_root();
-    let cargo_toml = get_cargo_toml_path(&rust_root);
+    let rust_root = match rust_paths::get_rust_root(None, true) {
+        Ok(root) => root,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
+    };
+    let cargo_toml = rust_paths::get_cargo_toml_path(&rust_root);
+    let package_manifest = match rust_paths::get_package_manifest_path(&cargo_toml) {
+        Ok(path) => path,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
+    };
 
     // Get token from CLI arg, then env vars
     let token = get_arg("token")
         .or_else(|| env::var("CARGO_REGISTRY_TOKEN").ok().filter(|s| !s.is_empty()))
         .or_else(|| env::var("CARGO_TOKEN").ok().filter(|s| !s.is_empty()));
 
-    let (name, version) = match get_package_info(&cargo_toml) {
+    let package_info = match rust_paths::read_package_info(&package_manifest) {
         Ok(info) => info,
         Err(e) => {
             eprintln!("Error: {}", e);
             exit(1);
         }
     };
+    let name = package_info.name;
+    let version = package_info.version;
 
     println!("Package: {}@{}", name, version);
 
@@ -154,7 +115,7 @@ fn main() {
 
     // Build the cargo publish command
     let mut cmd = Command::new("cargo");
-    cmd.arg("publish").arg("--allow-dirty");
+    cmd.arg("publish").arg("--allow-dirty").arg("-p").arg(&name);
 
     if let Some(t) = &token {
         cmd.arg("--token").arg(t);

--- a/scripts/rust-paths.rs
+++ b/scripts/rust-paths.rs
@@ -14,24 +14,32 @@
 //! Configuration options (in order of priority):
 //!   1. Explicit parameter passed to functions
 //!   2. CLI argument: --rust-root <path>
-//!   3. Environment variable: RUST_ROOT
+//!   3. Environment variable: `RUST_ROOT`
 //!   4. Auto-detection: Check ./Cargo.toml first, then ./rust/Cargo.toml
 
+use regex::Regex;
 use std::env;
+use std::fs;
 use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageInfo {
+    pub name: String,
+    pub version: String,
+}
 
 /// Detect Rust package root directory
 /// Checks in order:
-/// 1. Explicit rust_root parameter
+/// 1. Explicit `rust_root` parameter
 /// 2. --rust-root CLI argument
-/// 3. RUST_ROOT environment variable
+/// 3. `RUST_ROOT` environment variable
 /// 4. ./Cargo.toml (single-language repo)
 /// 5. ./rust/Cargo.toml (multi-language repo)
 pub fn get_rust_root(explicit_root: Option<&str>, verbose: bool) -> Result<String, String> {
     // If explicitly configured, use that
     if let Some(root) = explicit_root {
         if verbose {
-            eprintln!("Using explicitly configured Rust root: {}", root);
+            eprintln!("Using explicitly configured Rust root: {root}");
         }
         return Ok(root.to_string());
     }
@@ -41,7 +49,7 @@ pub fn get_rust_root(explicit_root: Option<&str>, verbose: bool) -> Result<Strin
     if let Some(idx) = args.iter().position(|a| a == "--rust-root") {
         if let Some(root) = args.get(idx + 1) {
             if verbose {
-                eprintln!("Using CLI configured Rust root: {}", root);
+                eprintln!("Using CLI configured Rust root: {root}");
             }
             return Ok(root.clone());
         }
@@ -51,7 +59,7 @@ pub fn get_rust_root(explicit_root: Option<&str>, verbose: bool) -> Result<Strin
     if let Ok(root) = env::var("RUST_ROOT") {
         if !root.is_empty() {
             if verbose {
-                eprintln!("Using environment configured Rust root: {}", root);
+                eprintln!("Using environment configured Rust root: {root}");
             }
             return Ok(root);
         }
@@ -74,8 +82,7 @@ pub fn get_rust_root(explicit_root: Option<&str>, verbose: bool) -> Result<Strin
     }
 
     // No Cargo.toml found
-    Err(
-        "Could not find Cargo.toml in expected locations.\n\
+    Err("Could not find Cargo.toml in expected locations.\n\
         Searched in:\n  \
         - ./Cargo.toml (single-language repository)\n  \
         - ./rust/Cargo.toml (multi-language repository)\n\n\
@@ -83,8 +90,7 @@ pub fn get_rust_root(explicit_root: Option<&str>, verbose: bool) -> Result<Strin
         1. Run the script from the repository root\n  \
         2. Explicitly configure the Rust root using --rust-root option\n  \
         3. Set the RUST_ROOT environment variable"
-            .to_string(),
-    )
+        .to_string())
 }
 
 /// Get the path to Cargo.toml
@@ -137,16 +143,127 @@ pub fn parse_rust_root_from_args() -> Option<String> {
     env::var("RUST_ROOT").ok().filter(|s| !s.is_empty())
 }
 
+pub fn get_package_manifest_path(root_manifest: &Path) -> Result<PathBuf, String> {
+    let content = fs::read_to_string(root_manifest)
+        .map_err(|e| format!("Failed to read {}: {}", root_manifest.display(), e))?;
+
+    if has_package_section(&content) {
+        return Ok(root_manifest.to_path_buf());
+    }
+
+    if has_workspace_section(&content) {
+        return resolve_workspace_member_manifest(root_manifest, &content);
+    }
+
+    Err(format!(
+        "Could not find [package] or [workspace] in {}",
+        root_manifest.display()
+    ))
+}
+
+pub fn read_package_info(manifest_path: &Path) -> Result<PackageInfo, String> {
+    let content = fs::read_to_string(manifest_path)
+        .map_err(|e| format!("Failed to read {}: {}", manifest_path.display(), e))?;
+
+    let name = find_manifest_value(&content, "name")
+        .ok_or_else(|| format!("Could not find name in {}", manifest_path.display()))?;
+    let version = find_manifest_value(&content, "version")
+        .ok_or_else(|| format!("Could not find version in {}", manifest_path.display()))?;
+
+    Ok(PackageInfo { name, version })
+}
+
+fn has_package_section(content: &str) -> bool {
+    Regex::new(r"(?m)^\[package\]\s*$")
+        .unwrap()
+        .is_match(content)
+}
+
+fn has_workspace_section(content: &str) -> bool {
+    Regex::new(r"(?m)^\[workspace\]\s*$")
+        .unwrap()
+        .is_match(content)
+}
+
+fn resolve_workspace_member_manifest(
+    root_manifest: &Path,
+    content: &str,
+) -> Result<PathBuf, String> {
+    let members = parse_workspace_members(content).ok_or_else(|| {
+        format!(
+            "Could not find workspace members in {}",
+            root_manifest.display()
+        )
+    })?;
+
+    let base_dir = root_manifest.parent().ok_or_else(|| {
+        format!(
+            "Could not determine parent directory for {}",
+            root_manifest.display()
+        )
+    })?;
+
+    for member in members {
+        let manifest = base_dir.join(member).join("Cargo.toml");
+        let Ok(member_content) = fs::read_to_string(&manifest) else {
+            continue;
+        };
+
+        if !has_package_section(&member_content) || is_publish_false(&member_content) {
+            continue;
+        }
+
+        return Ok(manifest);
+    }
+
+    Err(format!(
+        "No publishable workspace members found in {}",
+        root_manifest.display()
+    ))
+}
+
+fn parse_workspace_members(content: &str) -> Option<Vec<String>> {
+    let re = Regex::new(r"(?s)members\s*=\s*\[(.*?)\]").unwrap();
+    let captures = re.captures(content)?;
+    let body = captures.get(1)?.as_str();
+
+    let members = body
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| entry.trim_matches('"').to_string())
+        .filter(|entry| !entry.is_empty())
+        .collect::<Vec<_>>();
+
+    if members.is_empty() {
+        None
+    } else {
+        Some(members)
+    }
+}
+
+fn is_publish_false(content: &str) -> bool {
+    Regex::new(r"(?m)^publish\s*=\s*false\s*$")
+        .unwrap()
+        .is_match(content)
+}
+
+fn find_manifest_value(content: &str, key: &str) -> Option<String> {
+    let re = Regex::new(&format!(r#"(?m)^{}\s*=\s*"([^"]+)""#, regex::escape(key))).unwrap();
+    re.captures(content)
+        .and_then(|caps| caps.get(1).map(|m| m.as_str().to_string()))
+}
+
 fn main() {
     // When run directly, just print the detected rust root
     match get_rust_root(None, true) {
         Ok(root) => {
-            println!("Rust root: {}", root);
+            println!("Rust root: {root}");
             println!("Cargo.toml: {}", get_cargo_toml_path(&root).display());
             println!("Changelog dir: {}", get_changelog_dir(&root).display());
         }
         Err(e) => {
-            eprintln!("Error: {}", e);
+            eprintln!("Error: {e}");
             std::process::exit(1);
         }
     }

--- a/scripts/rust-paths.rs
+++ b/scripts/rust-paths.rs
@@ -254,6 +254,7 @@ fn find_manifest_value(content: &str, key: &str) -> Option<String> {
         .and_then(|caps| caps.get(1).map(|m| m.as_str().to_string()))
 }
 
+#[cfg(not(test))]
 fn main() {
     // When run directly, just print the detected rust root
     match get_rust_root(None, true) {

--- a/scripts/version-and-commit.rs
+++ b/scripts/version-and-commit.rs
@@ -32,6 +32,9 @@ use regex::Regex;
 use chrono::Utc;
 use serde::Deserialize;
 
+#[path = "rust-paths.rs"]
+mod rust_paths;
+
 fn get_arg(name: &str) -> Option<String> {
     let args: Vec<String> = env::args().collect();
     let flag = format!("--{}", name);
@@ -42,34 +45,6 @@ fn get_arg(name: &str) -> Option<String> {
 
     let env_name = name.to_uppercase().replace('-', "_");
     env::var(&env_name).ok().filter(|s| !s.is_empty())
-}
-
-fn get_rust_root() -> String {
-    if let Some(root) = get_arg("rust-root") {
-        eprintln!("Using explicitly configured Rust root: {}", root);
-        return root;
-    }
-
-    if Path::new("./Cargo.toml").exists() {
-        eprintln!("Detected single-language repository (Cargo.toml in root)");
-        return ".".to_string();
-    }
-
-    if Path::new("./rust/Cargo.toml").exists() {
-        eprintln!("Detected multi-language repository (Cargo.toml in rust/)");
-        return "rust".to_string();
-    }
-
-    eprintln!("Error: Could not find Cargo.toml in expected locations");
-    exit(1);
-}
-
-fn get_cargo_toml_path(rust_root: &str) -> String {
-    if rust_root == "." {
-        "./Cargo.toml".to_string()
-    } else {
-        format!("{}/Cargo.toml", rust_root)
-    }
 }
 
 fn get_changelog_dir(rust_root: &str) -> String {
@@ -391,8 +366,21 @@ fn main() {
     let description = get_arg("description");
     let tag_prefix = get_arg("tag-prefix").unwrap_or_else(|| "v".to_string());
     let release_label = get_arg("release-label");
-    let rust_root = get_rust_root();
-    let cargo_toml = get_cargo_toml_path(&rust_root);
+    let rust_root = match rust_paths::get_rust_root(None, true) {
+        Ok(root) => root,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
+    };
+    let cargo_toml = rust_paths::get_cargo_toml_path(&rust_root);
+    let package_manifest = match rust_paths::get_package_manifest_path(&cargo_toml) {
+        Ok(path) => path,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
+    };
     let changelog_dir = get_changelog_dir(&rust_root);
     let changelog_file = get_changelog_path(&rust_root);
 
@@ -401,10 +389,10 @@ fn main() {
     let _ = exec("git", &["config", "user.email", "github-actions[bot]@users.noreply.github.com"]);
 
     // Get current version
-    let content = match fs::read_to_string(&cargo_toml) {
+    let content = match fs::read_to_string(&package_manifest) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("Error reading {}: {}", cargo_toml, e);
+            eprintln!("Error reading {}: {}", package_manifest.display(), e);
             exit(1);
         }
     };
@@ -412,14 +400,14 @@ fn main() {
     let current = match Version::parse(&content) {
         Some(v) => v,
         None => {
-            eprintln!("Error: Could not parse version from {}", cargo_toml);
+            eprintln!("Error: Could not parse version from {}", package_manifest.display());
             exit(1);
         }
     };
 
     let initial_bump = current.bump(&bump_type);
 
-    let crate_name = match get_crate_name(&cargo_toml) {
+    let crate_name = match get_crate_name(package_manifest.to_string_lossy().as_ref()) {
         Ok(name) => name,
         Err(e) => {
             eprintln!("Error: {}", e);
@@ -448,7 +436,7 @@ fn main() {
     println!("Final release version: {}", new_version);
 
     // Update version in Cargo.toml
-    if let Err(e) = update_cargo_toml(&cargo_toml, &new_version) {
+    if let Err(e) = update_cargo_toml(package_manifest.to_string_lossy().as_ref(), &new_version) {
         eprintln!("Error: {}", e);
         exit(1);
     }
@@ -457,7 +445,8 @@ fn main() {
     collect_changelog(&changelog_dir, &changelog_file, &new_version);
 
     // Stage Cargo.toml and CHANGELOG.md
-    let _ = exec("git", &["add", &cargo_toml, &changelog_file]);
+    let package_manifest_str = package_manifest.to_string_lossy().to_string();
+    let _ = exec("git", &["add", &package_manifest_str, &changelog_file]);
 
     // Check if there are changes to commit
     if exec_check("git", &["diff", "--cached", "--quiet"]) {

--- a/tests/unit/ci-cd/mod.rs
+++ b/tests/unit/ci-cd/mod.rs
@@ -1,1 +1,4 @@
 mod changelog_parsing;
+#[path = "../../../scripts/rust-paths.rs"]
+mod rust_paths;
+mod workspace_manifest_resolution;

--- a/tests/unit/ci-cd/workspace_manifest_resolution.rs
+++ b/tests/unit/ci-cd/workspace_manifest_resolution.rs
@@ -1,0 +1,104 @@
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::rust_paths::{get_package_manifest_path, read_package_info};
+
+fn temp_dir(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("rust-paths-{name}-{nanos}"));
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+
+#[test]
+fn resolves_root_package_manifest_when_package_exists() {
+    let repo = temp_dir("root-package");
+    fs::write(
+        repo.join("Cargo.toml"),
+        r#"[package]
+name = "root-crate"
+version = "1.2.3"
+"#,
+    )
+    .unwrap();
+
+    let manifest = get_package_manifest_path(&repo.join("Cargo.toml")).unwrap();
+    let info = read_package_info(&manifest).unwrap();
+
+    assert_eq!(manifest, repo.join("Cargo.toml"));
+    assert_eq!(info.name, "root-crate");
+    assert_eq!(info.version, "1.2.3");
+}
+
+#[test]
+fn resolves_first_publishable_workspace_member() {
+    let repo = temp_dir("workspace-member");
+    fs::create_dir_all(repo.join("private-crate")).unwrap();
+    fs::create_dir_all(repo.join("public-crate")).unwrap();
+
+    fs::write(
+        repo.join("Cargo.toml"),
+        r#"[workspace]
+members = ["private-crate", "public-crate"]
+resolver = "2"
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        repo.join("private-crate/Cargo.toml"),
+        r#"[package]
+name = "private-crate"
+version = "0.1.0"
+publish = false
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        repo.join("public-crate/Cargo.toml"),
+        r#"[package]
+name = "public-crate"
+version = "0.2.0"
+"#,
+    )
+    .unwrap();
+
+    let manifest = get_package_manifest_path(&repo.join("Cargo.toml")).unwrap();
+    let info = read_package_info(&manifest).unwrap();
+
+    assert_eq!(manifest, repo.join("public-crate/Cargo.toml"));
+    assert_eq!(info.name, "public-crate");
+    assert_eq!(info.version, "0.2.0");
+}
+
+#[test]
+fn errors_when_workspace_has_no_publishable_members() {
+    let repo = temp_dir("no-publishable-members");
+    fs::create_dir_all(repo.join("private-crate")).unwrap();
+
+    fs::write(
+        repo.join("Cargo.toml"),
+        r#"[workspace]
+members = ["private-crate"]
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        repo.join("private-crate/Cargo.toml"),
+        r#"[package]
+name = "private-crate"
+version = "0.1.0"
+publish = false
+"#,
+    )
+    .unwrap();
+
+    let error = get_package_manifest_path(&repo.join("Cargo.toml")).unwrap_err();
+    assert!(error.contains("No publishable workspace members"));
+}

--- a/tests/unit/ci-cd/workspace_manifest_resolution.rs
+++ b/tests/unit/ci-cd/workspace_manifest_resolution.rs
@@ -2,7 +2,11 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use super::rust_paths::{get_package_manifest_path, read_package_info};
+use super::rust_paths::{
+    get_cargo_lock_path, get_cargo_toml_path, get_changelog_dir, get_changelog_path,
+    get_package_manifest_path, get_rust_root, needs_cd, parse_rust_root_from_args,
+    read_package_info,
+};
 
 fn temp_dir(name: &str) -> PathBuf {
     let nanos = SystemTime::now()
@@ -101,4 +105,42 @@ publish = false
 
     let error = get_package_manifest_path(&repo.join("Cargo.toml")).unwrap_err();
     assert!(error.contains("No publishable workspace members"));
+}
+
+#[test]
+fn path_helpers_match_repository_layout() {
+    assert_eq!(get_cargo_toml_path("."), PathBuf::from("./Cargo.toml"));
+    assert_eq!(get_cargo_lock_path("."), PathBuf::from("./Cargo.lock"));
+    assert_eq!(get_changelog_dir("."), PathBuf::from("./changelog.d"));
+    assert_eq!(get_changelog_path("."), PathBuf::from("./CHANGELOG.md"));
+    assert!(!needs_cd("."));
+
+    assert_eq!(
+        get_cargo_toml_path("rust"),
+        PathBuf::from("rust/Cargo.toml")
+    );
+    assert_eq!(
+        get_cargo_lock_path("rust"),
+        PathBuf::from("rust/Cargo.lock")
+    );
+    assert_eq!(get_changelog_dir("rust"), PathBuf::from("rust/changelog.d"));
+    assert_eq!(
+        get_changelog_path("rust"),
+        PathBuf::from("rust/CHANGELOG.md")
+    );
+    assert!(needs_cd("rust"));
+}
+
+#[test]
+fn rust_root_prefers_explicit_parameter() {
+    assert_eq!(
+        get_rust_root(Some("custom-root"), false).unwrap(),
+        "custom-root"
+    );
+}
+
+#[test]
+fn rust_root_cli_parser_returns_none_without_configuration() {
+    std::env::remove_var("RUST_ROOT");
+    assert_eq!(parse_rust_root_from_args(), None);
 }


### PR DESCRIPTION
## Summary
Fixes release automation for repositories that use a Cargo workspace manifest at the repo root.

Fixes #36

## What Changed
- add shared workspace-aware manifest resolution in `scripts/rust-paths.rs`
- make release/version scripts read `name` and `version` from the first publishable workspace member when the root manifest only contains `[workspace]`
- make `publish-crate.rs` publish the resolved package explicitly with `cargo publish -p <package>`
- add unit tests covering root package manifests, workspace member resolution, and the no-publishable-member error path
- add a changelog fragment for the fix

## Reproduction
1. Replace the root `Cargo.toml` with a workspace manifest containing only `[workspace]`
2. Move the publishable crate into a workspace member such as `my-crate/Cargo.toml`
3. Run the release scripts from the repository root
4. Before this change they failed reading `name`/`version` from the workspace root manifest

## Verification
- `cargo test`
- `cargo clippy --all-targets --all-features`
- `cargo fmt`

## Notes
- `rust-script scripts/check-file-size.rs` could not be run in this environment because `rust-script` is not installed.
