### PR TITLE
ci: add workflow job timeouts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
   detect-changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event_name != 'workflow_dispatch'
     outputs:
       rs-changed: ${{ steps.changes.outputs.rs-changed }}
@@ -74,6 +75,7 @@ jobs:
   changelog:
     name: Changelog Fragment Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [detect-changes]
     if: github.event_name == 'pull_request' && needs.detect-changes.outputs.any-code-changed == 'true'
     steps:
@@ -97,6 +99,7 @@ jobs:
   version-check:
     name: Version Modification Check
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v6
@@ -122,6 +125,7 @@ jobs:
   lint:
     name: Lint and Format Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [detect-changes]
     # Note: always() is required because detect-changes is skipped on workflow_dispatch,
     # and without always(), this job would also be skipped even though its condition includes workflow_dispatch.
@@ -171,6 +175,7 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     needs: [detect-changes, changelog]
     # Run if: push event, OR changelog succeeded, OR changelog was skipped (docs-only PR)
     if: always() && !cancelled() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.changelog.result == 'success' || needs.changelog.result == 'skipped')
@@ -206,6 +211,7 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [detect-changes]
     if: |
       always() && !cancelled() && (
@@ -250,6 +256,7 @@ jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [lint, test]
     if: always() && !cancelled() && needs.lint.result == 'success' && needs.test.result == 'success'
     steps:
@@ -288,6 +295,7 @@ jobs:
       github.ref == 'refs/heads/main' &&
       needs.build.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
     steps:
@@ -364,6 +372,7 @@ jobs:
       github.event.inputs.release_mode == 'instant' &&
       needs.build.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
     steps:
@@ -414,6 +423,7 @@ jobs:
     name: Create Changelog PR
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'changelog-pr'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write
@@ -471,6 +481,7 @@ jobs:
         (github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'instant')
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-03T11:14:06.504Z for PR creation at branch issue-41-6785a1a5c38d for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/41

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-03T11:14:06.504Z for PR creation at branch issue-41-6785a1a5c38d for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/41

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,8 @@ Thank you for your interest in contributing! This document provides guidelines a
    cargo test test_name
    ```
 
+   CI caps each test-matrix job at 10 minutes. Rust's built-in `cargo test` runner does not provide a portable global per-test timeout, so wrap long-running network, IO, or async tests with explicit test-level deadlines. If a repository adopts `cargo nextest`, configure runner deadlines with options such as `--slow-timeout` and `--leak-timeout`.
+
 5. **Add a changelog fragment**
 
    For any user-facing changes, create a changelog fragment:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ cargo test test_sum_positive_numbers
 cargo test -- --nocapture
 ```
 
+CI caps each test-matrix job at 10 minutes. `cargo test` does not provide a portable global per-test timeout, so long-running network, IO, or async tests should use explicit test-level timeouts. Repositories that adopt `cargo nextest` can configure runner deadlines with options such as `--slow-timeout` and `--leak-timeout`.
+
 ### Code Quality Checks
 
 ```bash

--- a/changelog.d/20260503_111500_ci_timeouts.md
+++ b/changelog.d/20260503_111500_ci_timeouts.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Changed
+- Added explicit GitHub Actions job timeouts and documented Rust test timeout guidance.

--- a/tests/unit/ci-cd/workflow_release.rs
+++ b/tests/unit/ci-cd/workflow_release.rs
@@ -33,6 +33,20 @@ fn job_block<'a>(workflow: &'a str, job_name: &str) -> &'a str {
     )
 }
 
+fn workflow_job_names(workflow: &str) -> Vec<&str> {
+    let marker = "jobs:\n";
+    let start = workflow.find(marker).unwrap() + marker.len();
+
+    workflow[start..]
+        .lines()
+        .filter_map(|line| {
+            let starts_at_job_indent = line.starts_with("  ") && !line.starts_with("    ");
+            (starts_at_job_indent && line.trim_end().ends_with(':'))
+                .then(|| line.trim().trim_end_matches(':'))
+        })
+        .collect()
+}
+
 #[test]
 fn documentation_deploy_is_independent_from_release_publication() {
     let workflow = release_workflow();
@@ -44,4 +58,38 @@ fn documentation_deploy_is_independent_from_release_publication() {
     assert!(!deploy_docs.contains("needs: [auto-release, manual-release]"));
     assert!(!deploy_docs.contains("needs.auto-release.result"));
     assert!(!deploy_docs.contains("needs.manual-release.result"));
+}
+
+#[test]
+fn release_workflow_jobs_have_explicit_timeouts() {
+    let workflow = release_workflow();
+    let expected_timeouts = [
+        ("detect-changes", 5),
+        ("changelog", 10),
+        ("version-check", 5),
+        ("lint", 10),
+        ("test", 10),
+        ("coverage", 15),
+        ("build", 10),
+        ("auto-release", 30),
+        ("manual-release", 30),
+        ("changelog-pr", 10),
+        ("deploy-docs", 15),
+    ];
+
+    let actual_jobs = workflow_job_names(&workflow);
+    let expected_jobs = expected_timeouts
+        .iter()
+        .map(|(job_name, _)| *job_name)
+        .collect::<Vec<_>>();
+    assert_eq!(actual_jobs, expected_jobs);
+
+    for (job_name, timeout_minutes) in expected_timeouts {
+        let job = job_block(&workflow, job_name);
+        let expected = format!("    timeout-minutes: {timeout_minutes}\n");
+        assert!(
+            job.contains(&expected),
+            "{job_name} should declare {expected:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #41.

- Added explicit `timeout-minutes` to every job in `.github/workflows/release.yml`: 5-minute fast checks, 10-minute lint/test/build/change jobs, 15-minute coverage/docs jobs, and 30-minute release jobs.
- Documented the Rust test timeout policy: CI uses a job-level cap because `cargo test` has no portable global per-test timeout, with `cargo nextest` guidance for repositories that adopt it.
- Added a workflow regression test that asserts the job list and timeout bands, plus a patch changelog fragment.

## Reproduction

Before the fix, `rg -n "timeout-minutes" .github/workflows` returned no matches. The new `release_workflow_jobs_have_explicit_timeouts` test failed against that state on the first missing timeout (`detect-changes`) and passes after the workflow update.

## Validation

- `cargo test release_workflow_jobs_have_explicit_timeouts --test unit` failed before the fix and passed after it
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features`
- `cargo test`
- `cargo test --doc`
- `rust-script scripts/check-file-size.rs`
- `GITHUB_BASE_REF=main rust-script scripts/check-changelog-fragment.rs`
