### PR TITLE
fix: warn on near-limit Rust files

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-03T11:14:13.611Z for PR creation at branch issue-40-e59b0ab0e829 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/40

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-03T11:14:13.611Z for PR creation at branch issue-40-e59b0ab0e829 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/40

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,11 +146,12 @@ checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "example-sum-package-name"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap",
  "lino-arguments",
  "regex",
+ "walkdir",
 ]
 
 [[package]]
@@ -245,6 +246,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +332,25 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ clap = { version = "4.4", features = ["derive", "env"] }
 
 [dev-dependencies]
 regex = "1"
+walkdir = "2"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/changelog.d/20260503_111700_file_size_warning_threshold.md
+++ b/changelog.d/20260503_111700_file_size_warning_threshold.md
@@ -1,0 +1,2 @@
+### Fixed
+- Added a non-blocking warning threshold to the Rust file-size check so near-limit files are surfaced before concurrent PR merges can exceed the hard limit.

--- a/scripts/check-file-size.rs
+++ b/scripts/check-file-size.rs
@@ -1,6 +1,6 @@
 #!/usr/bin/env rust-script
-//! Check for files exceeding the maximum allowed line count
-//! Exits with error code 1 if any files exceed the limit
+//! Check Rust files for maximum and warning line-count thresholds
+//! Exits with error code 1 if any files exceed the hard limit
 //!
 //! Usage: rust-script scripts/check-file-size.rs
 //!
@@ -11,25 +11,30 @@
 
 use std::fs;
 use std::path::Path;
+#[cfg(not(test))]
 use std::process::exit;
 use walkdir::WalkDir;
 
 const MAX_LINES: usize = 1000;
+const WARN_LINES: usize = 900;
 const FILE_EXTENSIONS: &[&str] = &[".rs"];
 const EXCLUDE_PATTERNS: &[&str] = &["target", ".git", "node_modules"];
 
 fn should_exclude(path: &Path) -> bool {
     let path_str = path.to_string_lossy();
-    EXCLUDE_PATTERNS.iter().any(|pattern| path_str.contains(pattern))
+    EXCLUDE_PATTERNS
+        .iter()
+        .any(|pattern| path_str.contains(pattern))
 }
 
 fn has_valid_extension(path: &Path) -> bool {
-    if let Some(ext) = path.extension() {
-        let ext_with_dot = format!(".{}", ext.to_string_lossy());
-        FILE_EXTENSIONS.contains(&ext_with_dot.as_str())
-    } else {
-        false
-    }
+    let Some(ext) = path.extension().and_then(|ext| ext.to_str()) else {
+        return false;
+    };
+
+    FILE_EXTENSIONS
+        .iter()
+        .any(|valid_ext| valid_ext.strip_prefix('.') == Some(ext))
 }
 
 fn count_lines(path: &Path) -> Result<usize, std::io::Error> {
@@ -37,20 +42,51 @@ fn count_lines(path: &Path) -> Result<usize, std::io::Error> {
     Ok(content.lines().count())
 }
 
-struct Violation {
+#[derive(Debug, PartialEq, Eq)]
+struct Finding {
     file: String,
     lines: usize,
 }
 
-fn main() {
-    println!("\nChecking Rust files for maximum {} lines...\n", MAX_LINES);
+#[derive(Debug, PartialEq, Eq)]
+struct CheckResult {
+    warnings: Vec<Finding>,
+    violations: Vec<Finding>,
+}
 
-    let cwd = std::env::current_dir().expect("Failed to get current directory");
-    let mut violations: Vec<Violation> = Vec::new();
+#[derive(Debug, PartialEq, Eq)]
+enum LineStatus {
+    WithinLimit,
+    Warning,
+    Violation,
+}
 
-    for entry in WalkDir::new(&cwd)
+const fn classify_line_count(line_count: usize) -> LineStatus {
+    if line_count > MAX_LINES {
+        LineStatus::Violation
+    } else if line_count > WARN_LINES {
+        LineStatus::Warning
+    } else {
+        LineStatus::WithinLimit
+    }
+}
+
+fn relative_path(path: &Path, cwd: &Path) -> String {
+    path.strip_prefix(cwd)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .to_string()
+}
+
+fn check_directory(cwd: &Path) -> CheckResult {
+    let mut result = CheckResult {
+        warnings: Vec::new(),
+        violations: Vec::new(),
+    };
+
+    for entry in WalkDir::new(cwd)
         .into_iter()
-        .filter_map(|e| e.ok())
+        .filter_map(std::result::Result::ok)
         .filter(|e| e.file_type().is_file())
     {
         let path = entry.path();
@@ -65,36 +101,190 @@ fn main() {
 
         match count_lines(path) {
             Ok(line_count) => {
-                if line_count > MAX_LINES {
-                    let relative_path = path
-                        .strip_prefix(&cwd)
-                        .unwrap_or(path)
-                        .to_string_lossy()
-                        .to_string();
-                    violations.push(Violation {
-                        file: relative_path,
-                        lines: line_count,
-                    });
+                let finding = Finding {
+                    file: relative_path(path, cwd),
+                    lines: line_count,
+                };
+
+                match classify_line_count(line_count) {
+                    LineStatus::Violation => result.violations.push(finding),
+                    LineStatus::Warning => result.warnings.push(finding),
+                    LineStatus::WithinLimit => {}
                 }
             }
-            Err(e) => {
-                eprintln!("Warning: Could not read {}: {}", path.display(), e);
+            Err(error) => {
+                eprintln!("Warning: Could not read {}: {error}", path.display());
             }
         }
     }
 
+    result
+}
+
+fn escape_annotation_property(value: &str) -> String {
+    value
+        .replace('%', "%25")
+        .replace('\r', "%0D")
+        .replace('\n', "%0A")
+        .replace(':', "%3A")
+        .replace(',', "%2C")
+}
+
+fn escape_annotation_message(value: &str) -> String {
+    value
+        .replace('%', "%25")
+        .replace('\r', "%0D")
+        .replace('\n', "%0A")
+}
+
+fn warning_annotation(finding: &Finding) -> String {
+    let message = format!(
+        "File has {} lines (approaching limit of {MAX_LINES}). Consider extracting code to keep at or below {WARN_LINES} lines and prevent concurrent PR merge limit violations.",
+        finding.lines
+    );
+
+    format!(
+        "::warning file={}::{}",
+        escape_annotation_property(&finding.file),
+        escape_annotation_message(&message)
+    )
+}
+
+#[cfg(not(test))]
+fn print_warnings(warnings: &[Finding]) {
+    if warnings.is_empty() {
+        return;
+    }
+
+    for warning in warnings {
+        let annotation = warning_annotation(warning);
+        println!("{annotation}");
+        println!(
+            "WARNING: {} has {} lines (approaching limit of {MAX_LINES}, warning threshold: {WARN_LINES})",
+            warning.file, warning.lines
+        );
+    }
+
+    println!();
+    println!(
+        "The following files are approaching the {MAX_LINES} line limit (>{WARN_LINES} lines):"
+    );
+    for warning in warnings {
+        println!("  {}", warning.file);
+    }
+    println!("\nConsider extracting code to prevent concurrent PR merge limit violations.\n");
+}
+
+#[cfg(not(test))]
+fn print_violations(violations: &[Finding]) {
     if violations.is_empty() {
+        return;
+    }
+
+    println!("Found files exceeding the line limit:\n");
+    for violation in violations {
+        println!(
+            "  {}: {} lines (exceeds {MAX_LINES})",
+            violation.file, violation.lines
+        );
+    }
+    println!("\nPlease refactor these files to be under {MAX_LINES} lines\n");
+}
+
+#[cfg(not(test))]
+fn main() {
+    println!(
+        "\nChecking Rust files for maximum {MAX_LINES} lines (warning above {WARN_LINES})...\n"
+    );
+
+    let cwd = std::env::current_dir().expect("Failed to get current directory");
+    let result = check_directory(&cwd);
+
+    print_warnings(&result.warnings);
+
+    if result.violations.is_empty() {
         println!("All files are within the line limit\n");
         exit(0);
     } else {
-        println!("Found files exceeding the line limit:\n");
-        for violation in &violations {
-            println!(
-                "  {}: {} lines (exceeds {})",
-                violation.file, violation.lines, MAX_LINES
-            );
-        }
-        println!("\nPlease refactor these files to be under {} lines\n", MAX_LINES);
+        print_violations(&result.violations);
         exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fmt::Write as _;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("check-file-size-{name}-{nanos}"));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn write_rust_file_with_lines(path: &Path, line_count: usize) {
+        let mut content = String::new();
+        for line in 1..=line_count {
+            writeln!(&mut content, "// line {line}").unwrap();
+        }
+        fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn classifies_warning_band_without_blocking() {
+        assert_eq!(classify_line_count(WARN_LINES), LineStatus::WithinLimit);
+        assert_eq!(classify_line_count(WARN_LINES + 1), LineStatus::Warning);
+        assert_eq!(classify_line_count(MAX_LINES), LineStatus::Warning);
+    }
+
+    #[test]
+    fn classifies_hard_limit_violations() {
+        assert_eq!(classify_line_count(MAX_LINES + 1), LineStatus::Violation);
+    }
+
+    #[test]
+    fn check_directory_reports_warning_and_violation_separately() {
+        let repo = temp_dir("thresholds");
+        let src_dir = repo.join("src");
+        fs::create_dir_all(&src_dir).unwrap();
+        write_rust_file_with_lines(&src_dir.join("near_limit.rs"), WARN_LINES + 1);
+        write_rust_file_with_lines(&src_dir.join("over_limit.rs"), MAX_LINES + 1);
+        write_rust_file_with_lines(&src_dir.join("small.rs"), WARN_LINES);
+
+        let result = check_directory(&repo);
+
+        assert_eq!(
+            result.warnings,
+            vec![Finding {
+                file: "src/near_limit.rs".to_string(),
+                lines: WARN_LINES + 1,
+            }]
+        );
+        assert_eq!(
+            result.violations,
+            vec![Finding {
+                file: "src/over_limit.rs".to_string(),
+                lines: MAX_LINES + 1,
+            }]
+        );
+    }
+
+    #[test]
+    fn warning_annotation_uses_github_actions_format() {
+        let finding = Finding {
+            file: "src/near_limit.rs".to_string(),
+            lines: WARN_LINES + 1,
+        };
+
+        assert_eq!(
+            warning_annotation(&finding),
+            "::warning file=src/near_limit.rs::File has 901 lines (approaching limit of 1000). Consider extracting code to keep at or below 900 lines and prevent concurrent PR merge limit violations."
+        );
     }
 }

--- a/scripts/check-file-size.rs
+++ b/scripts/check-file-size.rs
@@ -72,10 +72,13 @@ const fn classify_line_count(line_count: usize) -> LineStatus {
 }
 
 fn relative_path(path: &Path, cwd: &Path) -> String {
-    path.strip_prefix(cwd)
+    let relative = path
+        .strip_prefix(cwd)
         .unwrap_or(path)
         .to_string_lossy()
-        .to_string()
+        .to_string();
+
+    relative.replace(std::path::MAIN_SEPARATOR, "/")
 }
 
 fn check_directory(cwd: &Path) -> CheckResult {

--- a/tests/unit/ci-cd/mod.rs
+++ b/tests/unit/ci-cd/mod.rs
@@ -1,4 +1,6 @@
 mod changelog_parsing;
+#[path = "../../../scripts/check-file-size.rs"]
+mod check_file_size;
 #[path = "../../../scripts/rust-paths.rs"]
 mod rust_paths;
 mod workflow_release;


### PR DESCRIPTION
Fixes #40.

## Summary

- Add a `WARN_LINES = 900` warning band below the existing `MAX_LINES = 1000` hard limit in `scripts/check-file-size.rs`.
- Emit GitHub Actions `::warning file=...::...` annotations for Rust files with more than 900 and up to 1000 lines.
- Print a warning summary while keeping near-limit files non-blocking; files over 1000 lines still fail the script.
- Add unit coverage for threshold classification, warning/violation separation, and annotation formatting.
- Add a changelog fragment for the CI behavior change.

## Reproduction

Before this change, a 901-line `.rs` file exited successfully with only `All files are within the line limit`, so reviewers received no signal before concurrent PRs could cross the hard limit.

After this change:

- a 901-line `.rs` file emits a `::warning file=src/near_limit.rs::...` annotation, appears in the warning summary, and exits 0
- a 1001-line `.rs` file still appears in the violation summary and exits 1

## Verification

- `cargo fmt --check`
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets --all-features`
- `RUSTFLAGS=-Dwarnings cargo test --all-features`
- `RUSTFLAGS=-Dwarnings cargo test --doc --verbose`
- `RUSTFLAGS=-Dwarnings cargo build`
- `RUST_LOG=error rust-script scripts/check-file-size.rs`
- `RUST_LOG=error rust-script scripts/check-changelog-fragment.rs`
- `GITHUB_EVENT_NAME=pull_request GITHUB_HEAD_REF=issue-40-e59b0ab0e829 GITHUB_BASE_REF=main RUST_LOG=error rust-script scripts/check-version-modification.rs`
- Manual temp repros for 901-line warning behavior and 1001-line hard failure behavior
