### PR TITLE
fix: use language release titles

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-09T03:02:59.442Z for PR creation at branch issue-44-d97914938437 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/44

--- a/changelog.d/20260509_031015_human_readable_release_titles.md
+++ b/changelog.d/20260509_031015_human_readable_release_titles.md
@@ -1,0 +1,2 @@
+### Fixed
+- Made `create-github-release.rs` build GitHub release titles as `[Language] X.Y.Z` instead of reusing the tag prefix.

--- a/scripts/create-github-release.rs
+++ b/scripts/create-github-release.rs
@@ -4,7 +4,7 @@
 //! Automatically includes crates.io and docs.rs badges in release notes
 //! when the crate name can be detected from Cargo.toml.
 //!
-//! Usage: rust-script scripts/create-github-release.rs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--release-label <label>]
+//! Usage: rust-script scripts/create-github-release.rs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <name>] [--release-label <label>]
 //!
 //! ```cargo
 //! [dependencies]
@@ -13,14 +13,24 @@
 //! serde_json = "1"
 //! ```
 
-use std::env;
-use std::fs;
-use std::io::Write;
-use std::path::Path;
-use std::process::{Command, Stdio, exit};
 use regex::Regex;
+#[cfg(not(test))]
 use serde::Serialize;
+#[cfg(not(test))]
+use std::env;
+#[cfg(not(test))]
+use std::fs;
+#[cfg(not(test))]
+use std::io::Write;
+#[cfg(not(test))]
+use std::path::Path;
+#[cfg(not(test))]
+use std::process::{exit, Command, Stdio};
 
+#[cfg(not(test))]
+const USAGE: &str = "Usage: rust-script scripts/create-github-release.rs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <name>] [--release-label <label>]";
+
+#[cfg(not(test))]
 fn get_rust_root() -> String {
     if let Some(root) = get_arg("rust-root") {
         return root;
@@ -37,52 +47,110 @@ fn get_rust_root() -> String {
     ".".to_string()
 }
 
+#[cfg(not(test))]
 fn get_cargo_toml_path(rust_root: &str) -> String {
     if rust_root == "." {
         "./Cargo.toml".to_string()
     } else {
-        format!("{}/Cargo.toml", rust_root)
+        format!("{rust_root}/Cargo.toml")
     }
 }
 
+#[cfg(not(test))]
 fn get_crate_name_from_toml(cargo_toml_path: &str) -> Option<String> {
     let content = fs::read_to_string(cargo_toml_path).ok()?;
     let re = Regex::new(r#"(?m)^name\s*=\s*"([^"]+)""#).ok()?;
-    re.captures(&content).map(|c| c.get(1).unwrap().as_str().to_string())
+    re.captures(&content)
+        .map(|captures| captures.get(1).unwrap().as_str().to_string())
 }
 
+#[cfg(not(test))]
 fn get_arg(name: &str) -> Option<String> {
     let args: Vec<String> = env::args().collect();
-    let flag = format!("--{}", name);
+    let flag = format!("--{name}");
 
-    if let Some(idx) = args.iter().position(|a| a == &flag) {
+    if let Some(idx) = args.iter().position(|arg| arg == &flag) {
         return args.get(idx + 1).cloned();
     }
 
     let env_name = name.to_uppercase().replace('-', "_");
-    env::var(&env_name).ok().filter(|s| !s.is_empty())
+    env::var(&env_name).ok().filter(|value| !value.is_empty())
 }
 
+fn normalize_release_version(release_version: &str) -> String {
+    let trimmed = release_version.trim();
+    let semver_re =
+        Regex::new(r"(?i)(?:^|[-_])v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$")
+            .expect("release version regex should compile");
+
+    semver_re.captures(trimmed).map_or_else(
+        || {
+            trimmed
+                .strip_prefix('v')
+                .or_else(|| trimmed.strip_prefix('V'))
+                .unwrap_or(trimmed)
+                .to_string()
+        },
+        |captures| {
+            captures
+                .get(1)
+                .expect("release version regex should capture the semver")
+                .as_str()
+                .to_string()
+        },
+    )
+}
+
+fn build_release_tag(tag_prefix: &str, release_version: &str) -> String {
+    let normalized_semver = normalize_release_version(release_version);
+    format!("{tag_prefix}{normalized_semver}")
+}
+
+fn build_release_name(
+    language: &str,
+    release_version: &str,
+    release_label: Option<&str>,
+) -> String {
+    let trimmed_language = language.trim();
+    let language = if trimmed_language.is_empty() {
+        "Rust"
+    } else {
+        trimmed_language
+    };
+    let normalized_semver = normalize_release_version(release_version);
+    let name = format!("[{language}] {normalized_semver}");
+
+    match release_label
+        .map(str::trim)
+        .filter(|label| !label.is_empty())
+    {
+        Some(label) => format!("{name} ({label})"),
+        None => name,
+    }
+}
+
+#[cfg(not(test))]
 fn get_changelog_for_version(version: &str) -> String {
     let changelog_path = "CHANGELOG.md";
 
     if !Path::new(changelog_path).exists() {
-        return format!("Release v{}", version);
+        return format!("Release v{version}");
     }
 
     let content = match fs::read_to_string(changelog_path) {
-        Ok(c) => c,
-        Err(_) => return format!("Release v{}", version),
+        Ok(content) => content,
+        Err(_) => return format!("Release v{version}"),
     };
 
-    // Find the section for this version
     let escaped_version = regex::escape(version);
-    let header_pattern = format!(r"(?m)^## \[{}\]", escaped_version);
+    let header_pattern = format!(r"(?m)^## \[{escaped_version}\]");
     let header_re = Regex::new(&header_pattern).unwrap();
 
-    if let Some(m) = header_re.find(&content) {
-        let after_header = &content[m.end()..];
-        let body_start = after_header.find('\n').map_or(after_header.len(), |i| i + 1);
+    if let Some(version_header) = header_re.find(&content) {
+        let after_header = &content[version_header.end()..];
+        let body_start = after_header
+            .find('\n')
+            .map_or(after_header.len(), |i| i + 1);
         let body = &after_header[body_start..];
 
         let next_section_re = Regex::new(r"(?m)^## \[").unwrap();
@@ -94,92 +162,104 @@ fn get_changelog_for_version(version: &str) -> String {
 
         let trimmed = section_body.trim();
         if trimmed.is_empty() {
-            format!("Release v{}", version)
+            format!("Release v{version}")
         } else {
             trimmed.to_string()
         }
     } else {
-        format!("Release v{}", version)
+        format!("Release v{version}")
     }
 }
 
-#[derive(Serialize)]
+#[cfg_attr(not(test), derive(Serialize))]
+#[derive(Debug, PartialEq, Eq)]
 struct ReleasePayload {
     tag_name: String,
     name: String,
     body: String,
 }
 
+fn build_release_payload(
+    tag_prefix: &str,
+    release_version: &str,
+    language: &str,
+    release_label: Option<&str>,
+    body: String,
+) -> ReleasePayload {
+    ReleasePayload {
+        tag_name: build_release_tag(tag_prefix, release_version),
+        name: build_release_name(language, release_version, release_label),
+        body,
+    }
+}
+
+#[cfg(not(test))]
 fn main() {
     let version = match get_arg("release-version") {
-        Some(v) => v,
+        Some(version) => version,
         None => {
             eprintln!("Error: Missing required argument --release-version");
-            eprintln!("Usage: rust-script scripts/create-github-release.rs --release-version <version> --repository <repository>");
+            eprintln!("{USAGE}");
             exit(1);
         }
     };
 
     let repository = match get_arg("repository") {
-        Some(r) => r,
+        Some(repository) => repository,
         None => {
             eprintln!("Error: Missing required argument --repository");
-            eprintln!("Usage: rust-script scripts/create-github-release.rs --release-version <version> --repository <repository>");
+            eprintln!("{USAGE}");
             exit(1);
         }
     };
 
     let tag_prefix = get_arg("tag-prefix").unwrap_or_else(|| "v".to_string());
+    let language = get_arg("language").unwrap_or_else(|| "Rust".to_string());
     let release_label = get_arg("release-label");
     let crates_io_url = get_arg("crates-io-url");
+    let normalized_version = normalize_release_version(&version);
 
     let rust_root = get_rust_root();
     let cargo_toml = get_cargo_toml_path(&rust_root);
 
     if let Some(ref crate_name) = get_crate_name_from_toml(&cargo_toml) {
         if crate_name == "example-sum-package-name" {
-            println!("Skipping GitHub release: package name is the template default 'example-sum-package-name'");
+            println!(
+                "Skipping GitHub release: package name is the template default 'example-sum-package-name'"
+            );
             println!("Rename the package in Cargo.toml before creating releases");
             return;
         }
     }
 
-    let tag = format!("{}{}", tag_prefix, version);
-    println!("Creating GitHub release for {}...", tag);
-
-    let mut release_notes = get_changelog_for_version(&version);
+    let mut release_notes = get_changelog_for_version(&normalized_version);
     if let Some(crate_name) = get_crate_name_from_toml(&cargo_toml) {
         let badges = format!(
-            "[![Crates.io](https://img.shields.io/crates/v/{}?label=crates.io)](https://crates.io/crates/{}/{}) [![Docs.rs](https://docs.rs/{}/badge.svg)](https://docs.rs/{}/{})",
-            crate_name, crate_name, version, crate_name, crate_name, version
+            "[![Crates.io](https://img.shields.io/crates/v/{crate_name}?label=crates.io)](https://crates.io/crates/{crate_name}/{normalized_version}) [![Docs.rs](https://docs.rs/{crate_name}/badge.svg)](https://docs.rs/{crate_name}/{normalized_version})"
         );
-        release_notes = format!("{}\n\n{}", badges, release_notes);
+        release_notes = format!("{badges}\n\n{release_notes}");
     }
 
-    // Add explicit crates.io link if provided (overrides auto-detected)
     if let Some(url) = crates_io_url {
-        release_notes = format!("{}\n\n{}", url, release_notes);
+        release_notes = format!("{url}\n\n{release_notes}");
     }
 
-    // Build release name with optional label for multi-language repos
-    let release_name = match &release_label {
-        Some(label) => format!("{}{} ({})", tag_prefix, version, label),
-        None => format!("{}{}", tag_prefix, version),
-    };
-
-    // Create release using GitHub API with JSON input
-    let payload = ReleasePayload {
-        tag_name: tag.clone(),
-        name: release_name,
-        body: release_notes,
-    };
+    let payload = build_release_payload(
+        &tag_prefix,
+        &normalized_version,
+        &language,
+        release_label.as_deref(),
+        release_notes,
+    );
+    let tag = payload.tag_name.clone();
+    println!("Creating GitHub release for {} ({})...", tag, payload.name);
 
     let payload_json = serde_json::to_string(&payload).expect("Failed to serialize payload");
 
     let mut child = Command::new("gh")
         .args([
             "api",
-            &format!("repos/{}/releases", repository),
+            &format!("repos/{repository}/releases"),
             "-X",
             "POST",
             "--input",
@@ -192,24 +272,85 @@ fn main() {
         .expect("Failed to execute gh command");
 
     if let Some(ref mut stdin) = child.stdin {
-        stdin.write_all(payload_json.as_bytes()).expect("Failed to write to stdin");
+        stdin
+            .write_all(payload_json.as_bytes())
+            .expect("Failed to write to stdin");
     }
 
-    let output = child.wait_with_output().expect("Failed to wait on gh command");
+    let output = child
+        .wait_with_output()
+        .expect("Failed to wait on gh command");
 
     if output.status.success() {
-        println!("Created GitHub release: {}", tag);
+        println!("Created GitHub release: {tag}");
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
         let stdout = String::from_utf8_lossy(&output.stdout);
-        let combined = format!("{}{}", stderr, stdout);
-        if combined.contains("already exists") || combined.contains("already_exists")
+        let combined = format!("{stderr}{stdout}");
+        if combined.contains("already exists")
+            || combined.contains("already_exists")
             || combined.contains("Validation Failed")
         {
-            println!("Release {} already exists, skipping", tag);
+            println!("Release {tag} already exists, skipping");
         } else {
-            eprintln!("Error creating release: {}", stderr);
+            eprintln!("Error creating release: {stderr}");
             exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_title_uses_language_and_bare_semver() {
+        assert_eq!(
+            build_release_name("Rust", "rust-v0.2.1", None),
+            "[Rust] 0.2.1"
+        );
+        assert_eq!(
+            build_release_name("JavaScript", "js_v1.2.3", None),
+            "[JavaScript] 1.2.3"
+        );
+    }
+
+    #[test]
+    fn release_title_defaults_empty_language_to_rust() {
+        assert_eq!(build_release_name(" ", "0.2.1", None), "[Rust] 0.2.1");
+    }
+
+    #[test]
+    fn release_label_remains_optional_suffix() {
+        assert_eq!(
+            build_release_name("Rust", "0.2.1", Some("stable")),
+            "[Rust] 0.2.1 (stable)"
+        );
+        assert_eq!(
+            build_release_name("Rust", "0.2.1", Some(" ")),
+            "[Rust] 0.2.1"
+        );
+    }
+
+    #[test]
+    fn release_tag_uses_prefix_with_normalized_semver() {
+        assert_eq!(build_release_tag("rust-v", "0.2.1"), "rust-v0.2.1");
+        assert_eq!(build_release_tag("rust_v", "rust-v0.2.1"), "rust_v0.2.1");
+        assert_eq!(build_release_tag("v", "v0.2.1"), "v0.2.1");
+    }
+
+    #[test]
+    fn release_payload_keeps_tag_prefix_out_of_release_name() {
+        let payload =
+            build_release_payload("rust-v", "0.2.1", "Rust", None, "release notes".to_string());
+
+        assert_eq!(
+            payload,
+            ReleasePayload {
+                tag_name: "rust-v0.2.1".to_string(),
+                name: "[Rust] 0.2.1".to_string(),
+                body: "release notes".to_string(),
+            }
+        );
     }
 }

--- a/tests/unit/ci-cd/mod.rs
+++ b/tests/unit/ci-cd/mod.rs
@@ -1,6 +1,8 @@
 mod changelog_parsing;
 #[path = "../../../scripts/check-file-size.rs"]
 mod check_file_size;
+#[path = "../../../scripts/create-github-release.rs"]
+mod create_github_release;
 #[path = "../../../scripts/rust-paths.rs"]
 mod rust_paths;
 mod workflow_release;


### PR DESCRIPTION
## Summary

- Added a `--language` option to `scripts/create-github-release.rs`, defaulting to `Rust`.
- Split release tag and release title formatting so `--tag-prefix` only affects `tag_name`; the GitHub release `name` is now `[Language] X.Y.Z` with the existing `--release-label` kept as an optional suffix.
- Normalized prefixed release versions such as `rust-v0.2.1` / `rust_v0.2.1` before building titles, tags, changelog lookups, and registry links.
- Added regression coverage by including `create-github-release.rs` in the unit test suite, plus a changelog fragment for the user-facing behavior change.

Fixes #44

## Root Cause

`create-github-release.rs` reused `format!("{}{}", tag_prefix, version)` for the release payload `name`. That made the human-visible release title equal to the tag, so multi-language prefixes such as `rust-v` produced titles like `rust-v0.2.1` instead of `[Rust] 0.2.1`.

## Test Plan

- [x] Reproduced the bug with a failing regression before the fix (`release_name_is_language_title_not_tag_name`).
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all-features --verbose`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `rust-script scripts/check-file-size.rs`
- [x] `rust-script scripts/create-github-release.rs --release-version 0.2.1 --repository owner/repo` (compiles and exits through the template-package skip path)
