### PR TITLE
ci: add optional Docker Hub release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ env:
   # Support both CARGO_REGISTRY_TOKEN (cargo's native env var) and CARGO_TOKEN (for backwards compatibility)
   CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
   CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+  # Optional: set repository variable DOCKERHUB_IMAGE to namespace/image to publish Docker Hub releases.
+  DOCKERHUB_IMAGE: ${{ vars.DOCKERHUB_IMAGE }}
 
 jobs:
   # === DETECT CHANGES - determines which jobs should run ===
@@ -296,6 +298,9 @@ jobs:
       needs.build.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME || secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       contents: write
     steps:
@@ -321,6 +326,7 @@ jobs:
         id: check
         env:
           HAS_FRAGMENTS: ${{ steps.bump_type.outputs.has_fragments }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: rust-script scripts/check-release-needed.rs
 
       - name: Collect changelog and bump version
@@ -340,24 +346,97 @@ jobs:
         run: cargo build --release
 
       - name: Publish to Crates.io
-        if: steps.check.outputs.should_release == 'true'
+        if: steps.check.outputs.should_release == 'true' && steps.check.outputs.crate_published != 'true'
         id: publish-crate
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
           CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
         run: rust-script scripts/publish-crate.rs
 
+      - name: Wait for Crate availability on Crates.io
+        if: steps.check.outputs.should_release == 'true'
+        run: rust-script scripts/wait-for-crate.rs --release-version "${{ steps.current_version.outputs.version }}"
+
+      - name: Configure Docker Hub publishing
+        if: steps.check.outputs.should_release == 'true'
+        id: dockerhub
+        run: |
+          disable_dockerhub() {
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "$1"
+          }
+
+          if [ -z "$DOCKERHUB_IMAGE" ]; then
+            disable_dockerhub "Docker Hub publishing disabled: DOCKERHUB_IMAGE repository variable is not set"
+            exit 0
+          fi
+
+          if [ ! -f Dockerfile ]; then
+            disable_dockerhub "Docker Hub publishing disabled: Dockerfile was not found at repository root"
+            exit 0
+          fi
+
+          if [ -z "$DOCKERHUB_USERNAME" ] || [ -z "$DOCKERHUB_TOKEN" ]; then
+            echo "::error::Docker Hub publishing requires DOCKERHUB_USERNAME and DOCKERHUB_TOKEN"
+            echo "Set DOCKERHUB_USERNAME as a repository variable or secret, and DOCKERHUB_TOKEN as a secret."
+            exit 1
+          fi
+
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+          echo "docker_hub_url=https://hub.docker.com/r/${DOCKERHUB_IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        if: steps.dockerhub.outputs.enabled == 'true'
+        uses: docker/login-action@v4
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.dockerhub.outputs.enabled == 'true'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Extract Docker metadata
+        if: steps.dockerhub.outputs.enabled == 'true'
+        id: docker-meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.DOCKERHUB_IMAGE }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ steps.current_version.outputs.version }}
+          labels: |
+            org.opencontainers.image.version=${{ steps.current_version.outputs.version }}
+
+      - name: Publish Docker image to Docker Hub
+        if: steps.dockerhub.outputs.enabled == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.docker-meta.outputs.tags }}
+          labels: ${{ steps.docker-meta.outputs.labels }}
+
       - name: Create GitHub Release
         if: steps.check.outputs.should_release == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_HUB_URL: ${{ steps.dockerhub.outputs.docker_hub_url }}
         run: |
           # Use new_version from version-and-commit when available (tag-checked), else fall back to Cargo.toml version
           RELEASE_VERSION="${{ steps.version.outputs.new_version }}"
           if [ -z "$RELEASE_VERSION" ]; then
             RELEASE_VERSION="${{ steps.current_version.outputs.version }}"
           fi
-          rust-script scripts/create-github-release.rs --release-version "$RELEASE_VERSION" --repository "${{ github.repository }}"
+
+          release_args=(
+            --release-version "$RELEASE_VERSION"
+            --repository "${{ github.repository }}"
+          )
+          if [ -n "$DOCKER_HUB_URL" ]; then
+            release_args+=(--docker-hub-url "$DOCKER_HUB_URL")
+          fi
+          rust-script scripts/create-github-release.rs "${release_args[@]}"
 
   # === MANUAL INSTANT RELEASE ===
   # Manual release via workflow_dispatch - only after CI passes
@@ -373,6 +452,9 @@ jobs:
       needs.build.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME || secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       contents: write
     steps:
@@ -412,11 +494,84 @@ jobs:
           CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
         run: rust-script scripts/publish-crate.rs
 
+      - name: Wait for Crate availability on Crates.io
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        run: rust-script scripts/wait-for-crate.rs --release-version "${{ steps.version.outputs.new_version }}"
+
+      - name: Configure Docker Hub publishing
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        id: dockerhub
+        run: |
+          disable_dockerhub() {
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "$1"
+          }
+
+          if [ -z "$DOCKERHUB_IMAGE" ]; then
+            disable_dockerhub "Docker Hub publishing disabled: DOCKERHUB_IMAGE repository variable is not set"
+            exit 0
+          fi
+
+          if [ ! -f Dockerfile ]; then
+            disable_dockerhub "Docker Hub publishing disabled: Dockerfile was not found at repository root"
+            exit 0
+          fi
+
+          if [ -z "$DOCKERHUB_USERNAME" ] || [ -z "$DOCKERHUB_TOKEN" ]; then
+            echo "::error::Docker Hub publishing requires DOCKERHUB_USERNAME and DOCKERHUB_TOKEN"
+            echo "Set DOCKERHUB_USERNAME as a repository variable or secret, and DOCKERHUB_TOKEN as a secret."
+            exit 1
+          fi
+
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+          echo "docker_hub_url=https://hub.docker.com/r/${DOCKERHUB_IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        if: steps.dockerhub.outputs.enabled == 'true'
+        uses: docker/login-action@v4
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.dockerhub.outputs.enabled == 'true'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Extract Docker metadata
+        if: steps.dockerhub.outputs.enabled == 'true'
+        id: docker-meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.DOCKERHUB_IMAGE }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ steps.version.outputs.new_version }}
+          labels: |
+            org.opencontainers.image.version=${{ steps.version.outputs.new_version }}
+
+      - name: Publish Docker image to Docker Hub
+        if: steps.dockerhub.outputs.enabled == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.docker-meta.outputs.tags }}
+          labels: ${{ steps.docker-meta.outputs.labels }}
+
       - name: Create GitHub Release
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: rust-script scripts/create-github-release.rs --release-version "${{ steps.version.outputs.new_version }}" --repository "${{ github.repository }}"
+          DOCKER_HUB_URL: ${{ steps.dockerhub.outputs.docker_hub_url }}
+        run: |
+          release_args=(
+            --release-version "${{ steps.version.outputs.new_version }}"
+            --repository "${{ github.repository }}"
+          )
+          if [ -n "$DOCKER_HUB_URL" ]; then
+            release_args+=(--docker-hub-url "$DOCKER_HUB_URL")
+          fi
+          rust-script scripts/create-github-release.rs "${release_args[@]}"
 
   # === MANUAL CHANGELOG PR ===
   changelog-pr:

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-09T03:02:59.442Z for PR creation at branch issue-44-d97914938437 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/44
+# Updated: 2026-05-09T20:34:32.930Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-09T03:02:59.442Z for PR creation at branch issue-44-d97914938437 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/44
-# Updated: 2026-05-09T20:34:32.930Z

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "example-sum-package-name"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "clap",
  "lino-arguments",

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A comprehensive template for AI-driven Rust development with full CI/CD pipeline
 - **CI/CD pipeline**: GitHub Actions with multi-platform support
 - **Changelog management**: Fragment-based changelog (like Changesets/Scriv)
 - **Code coverage**: Automated coverage reports with cargo-llvm-cov and Codecov
-- **Release automation**: Automatic GitHub releases and crates.io publishing
+- **Release automation**: Automatic GitHub releases, crates.io publishing, and optional Docker Hub image publishing
 - **Template-safe defaults**: CI/CD skips publishing when package name is `example-sum-package-name`
 
 ## Quick Start
@@ -125,7 +125,8 @@ cargo fmt --check && cargo clippy --all-targets --all-features && rust-script sc
 │   ├── git-config.rs               # Git configuration for CI
 │   ├── publish-crate.rs            # Crates.io publishing
 │   ├── rust-paths.rs               # Rust root path detection
-│   └── version-and-commit.rs       # CI/CD version management
+│   ├── version-and-commit.rs       # CI/CD version management
+│   └── wait-for-crate.rs           # Crates.io availability wait before image publishing
 ├── src/
 │   ├── lib.rs                      # Library entry point
 │   ├── main.rs                     # CLI binary (uses lino-arguments)
@@ -204,13 +205,15 @@ The GitHub Actions workflow provides:
 7. **Building**: Release build and package validation
 8. **Auto release**: Automatic releases when changelog fragments are merged to main
 9. **Manual release**: Workflow dispatch with version bump type selection
-10. **Documentation**: Automatic docs deployment to GitHub Pages after release
+10. **Optional Docker Hub publishing**: Pushes `latest` and version tags after the matching crates.io version is visible
+11. **Documentation**: Automatic docs deployment to GitHub Pages after release
 
 ### Template-Safe Defaults
 
 The default package name `example-sum-package-name` triggers skip logic in CI/CD scripts:
 - `publish-crate.rs` skips crates.io publishing
 - `create-github-release.rs` skips GitHub release creation
+- Docker Hub publishing stays disabled unless `DOCKERHUB_IMAGE` is configured and a root `Dockerfile` exists
 
 Rename the package in `Cargo.toml` to enable full CI/CD publishing.
 
@@ -232,6 +235,24 @@ After creating a repository from this template:
    - `examples/basic_usage.rs`
 
 3. Update badges in this `README.md`
+
+### Optional Docker Hub Publishing
+
+Projects that ship a Docker image can publish Docker Hub releases from the same Rust release workflow. Add a root `Dockerfile`, then configure:
+
+| Name | Type | Example | Purpose |
+| ---- | ---- | ------- | ------- |
+| `DOCKERHUB_IMAGE` | Repository variable | `my-dockerhub-user/my-image` | Docker Hub repository to publish |
+| `DOCKERHUB_USERNAME` | Repository variable or secret | `my-dockerhub-user` | Docker Hub login username |
+| `DOCKERHUB_TOKEN` | Repository secret | Docker Hub access token | Docker Hub login token |
+
+When configured, the release workflow publishes both `latest` and the Cargo package version tag, for example `my-dockerhub-user/my-image:0.10.0`. Docker publishing runs only after crates.io reports the matching version as available, and release checks rerun missing Docker Hub or GitHub release artifacts without bumping the version again.
+
+Add a visible Docker Hub badge next to the crates.io badge in repositories that enable image publishing:
+
+```markdown
+[![Docker Hub](https://img.shields.io/docker/v/my-dockerhub-user/my-image?label=docker%20hub)](https://hub.docker.com/r/my-dockerhub-user/my-image)
+```
 
 ## Scripts Reference
 

--- a/changelog.d/20260509_205000_docker_hub_release_publishing.md
+++ b/changelog.d/20260509_205000_docker_hub_release_publishing.md
@@ -1,0 +1,9 @@
+---
+bump: minor
+---
+
+### Added
+- Added optional Docker Hub image publishing tied to Rust crate releases, including crates.io visibility waiting, version/latest image tags, and Docker Hub badges in GitHub release notes.
+
+### Changed
+- Release completeness checks now self-heal when crates.io exists but configured Docker Hub or GitHub release artifacts are missing.

--- a/docs/ci-cd/troubleshooting.md
+++ b/docs/ci-cd/troubleshooting.md
@@ -7,8 +7,9 @@ This guide covers common CI/CD issues and their solutions for Rust projects usin
 1. [Release Jobs Skipped](#release-jobs-skipped)
 2. [Version Already Released (False Positive)](#version-already-released-false-positive)
 3. [Crates.io Publishing Fails](#cratesio-publishing-fails)
-4. [Secret Configuration Issues](#secret-configuration-issues)
-5. [Multi-Language Repository Issues](#multi-language-repository-issues)
+4. [Docker Hub Publishing Fails](#docker-hub-publishing-fails)
+5. [Secret Configuration Issues](#secret-configuration-issues)
+6. [Multi-Language Repository Issues](#multi-language-repository-issues)
 
 ---
 
@@ -115,6 +116,44 @@ The "Publish to Crates.io" step fails with an error.
 
 ---
 
+## Docker Hub Publishing Fails
+
+### Symptom
+The crates.io publish succeeds, but the release workflow fails before or during Docker Hub publishing.
+
+### Required Configuration
+
+Docker Hub publishing is optional. It runs only when all of these are true:
+
+- A root `Dockerfile` exists
+- Repository variable `DOCKERHUB_IMAGE` is set to `namespace/repository`
+- `DOCKERHUB_USERNAME` is set as a repository variable or secret
+- Repository secret `DOCKERHUB_TOKEN` is set
+
+### Common Errors
+
+#### "Docker Hub publishing requires DOCKERHUB_USERNAME and DOCKERHUB_TOKEN"
+**Cause:** `DOCKERHUB_IMAGE` and `Dockerfile` enabled Docker publishing, but credentials are incomplete.
+
+**Solution:** Set `DOCKERHUB_USERNAME` and create a Docker Hub access token stored as `DOCKERHUB_TOKEN`.
+
+#### Docker tag is missing after crates.io already published
+**Cause:** A previous release run published the crate, then failed before Docker Hub or GitHub Release completed.
+
+**Solution:** Re-run the release workflow after fixing the Docker Hub configuration. The release check treats the version as incomplete and recreates missing artifacts without bumping the Cargo version again.
+
+### Verification
+Check whether a Docker Hub tag exists:
+
+```bash
+curl -fsSL "https://hub.docker.com/v2/repositories/NAMESPACE/REPOSITORY/tags/VERSION"
+```
+
+### Reference
+- [Docker GitHub Actions guide](https://docs.docker.com/build/ci/github-actions/)
+
+---
+
 ## Secret Configuration Issues
 
 ### Required Secrets
@@ -122,6 +161,7 @@ The "Publish to Crates.io" step fails with an error.
 | Secret Name | Purpose | Where to Get |
 |------------|---------|--------------|
 | `CARGO_REGISTRY_TOKEN` or `CARGO_TOKEN` | Publish to crates.io | https://crates.io/settings/tokens |
+| `DOCKERHUB_TOKEN` | Publish to Docker Hub when `DOCKERHUB_IMAGE` is configured | https://app.docker.com/settings/personal-access-tokens |
 | `GITHUB_TOKEN` | Create GitHub releases | Automatic (provided by GitHub) |
 
 ### Organization vs Repository Secrets

--- a/scripts/check-release-needed.rs
+++ b/scripts/check-release-needed.rs
@@ -4,12 +4,13 @@
 //! This script checks:
 //! 1. If there are changelog fragments to process
 //! 2. If the current version has already been published to crates.io
+//! 3. If the matching GitHub release and configured Docker Hub image tag exist
 //!
-//! IMPORTANT: This script checks crates.io (the source of truth for Rust packages),
-//! NOT git tags. This is critical because:
+//! IMPORTANT: This script checks external release artifacts, NOT git tags.
+//! This is critical because:
 //! - Git tags can exist without the package being published
-//! - GitHub releases create tags but don't publish to crates.io
-//! - Only crates.io publication means users can actually install the package
+//! - GitHub releases create tags but do not publish to crates.io or Docker Hub
+//! - A crates.io publish can succeed while later Docker/GitHub release steps fail
 //!
 //! Supports both single-language and multi-language repository structures:
 //! - Single-language: Cargo.toml in repository root
@@ -19,10 +20,16 @@
 //!
 //! Environment variables:
 //!   - HAS_FRAGMENTS: 'true' if changelog fragments exist (from get-bump-type.rs)
+//!   - DOCKERHUB_IMAGE: Optional Docker Hub image name to verify (namespace/repository)
+//!   - GITHUB_REPOSITORY: GitHub repository to verify (owner/repository)
 //!
 //! Outputs (written to GITHUB_OUTPUT):
 //!   - should_release: 'true' if a release should be created
-//!   - skip_bump: 'true' if version bump should be skipped (version not yet released)
+//!   - skip_bump: 'true' if version bump should be skipped while missing artifacts are recreated
+//!   - crate_published: 'true' if the current version already exists on crates.io
+//!   - dockerhub_required: 'true' if Docker Hub publishing is configured and a Dockerfile exists
+//!   - dockerhub_published: 'true' if the configured Docker Hub tag exists
+//!   - github_release_published: 'true' if the matching GitHub release exists
 //!   - max_published_version: the highest non-yanked version on crates.io (for downstream use)
 //!
 //! ```cargo
@@ -33,13 +40,26 @@
 //! serde_json = "1"
 //! ```
 
+use serde::Deserialize;
 use std::env;
 use std::fs;
+use std::path::Path;
 use std::process::exit;
-use serde::Deserialize;
 
 #[path = "rust-paths.rs"]
 mod rust_paths;
+
+fn get_arg(name: &str) -> Option<String> {
+    let args: Vec<String> = env::args().collect();
+    let flag = format!("--{}", name);
+
+    if let Some(idx) = args.iter().position(|a| a == &flag) {
+        return args.get(idx + 1).cloned();
+    }
+
+    let env_name = name.to_uppercase().replace('-', "_");
+    env::var(&env_name).ok().filter(|s| !s.is_empty())
+}
 
 fn set_output(key: &str, value: &str) {
     if let Ok(output_file) = env::var("GITHUB_OUTPUT") {
@@ -97,14 +117,94 @@ fn check_version_on_crates_io(crate_name: &str, version: &str) -> bool {
             }
             false
         }
-        Err(ureq::Error::Status(404, _)) => {
-            false
-        }
+        Err(ureq::Error::Status(404, _)) => false,
         Err(e) => {
             eprintln!("Warning: Could not check crates.io: {}", e);
             false
         }
     }
+}
+
+fn split_docker_image(image: &str) -> Option<(&str, &str)> {
+    let mut parts = image.split('/');
+    let namespace = parts.next()?;
+    let repository = parts.next()?;
+
+    if parts.next().is_some() || namespace.is_empty() || repository.is_empty() {
+        None
+    } else {
+        Some((namespace, repository))
+    }
+}
+
+fn check_docker_hub_tag(image: &str, version: &str) -> bool {
+    let Some((namespace, repository)) = split_docker_image(image) else {
+        eprintln!(
+            "Warning: Could not parse Docker Hub image '{}'; expected namespace/repository",
+            image
+        );
+        return false;
+    };
+
+    let url = format!(
+        "https://hub.docker.com/v2/repositories/{}/{}/tags/{}",
+        namespace, repository, version
+    );
+
+    match ureq::get(&url)
+        .set("User-Agent", "rust-script-check-release")
+        .call()
+    {
+        Ok(response) => response.status() == 200,
+        Err(ureq::Error::Status(404, _)) => false,
+        Err(e) => {
+            eprintln!("Warning: Could not check Docker Hub tag: {}", e);
+            false
+        }
+    }
+}
+
+fn check_github_release(repository: &str, tag_prefix: &str, version: &str) -> bool {
+    let url = format!(
+        "https://api.github.com/repos/{}/releases/tags/{}{}",
+        repository, tag_prefix, version
+    );
+
+    let mut request = ureq::get(&url)
+        .set("User-Agent", "rust-script-check-release")
+        .set("Accept", "application/vnd.github+json");
+
+    if let Ok(token) = env::var("GITHUB_TOKEN") {
+        if !token.is_empty() {
+            let auth_header = format!("Bearer {}", token);
+            request = request.set("Authorization", &auth_header);
+        }
+    }
+
+    match request.call() {
+        Ok(response) => response.status() == 200,
+        Err(ureq::Error::Status(404, _)) => false,
+        Err(e) => {
+            eprintln!("Warning: Could not check GitHub release: {}", e);
+            false
+        }
+    }
+}
+
+fn docker_hub_image_to_check() -> Option<String> {
+    get_arg("dockerhub-image")
+        .or_else(|| get_arg("docker-hub-image"))
+        .or_else(|| get_arg("dockerhub_image"))
+        .filter(|image| Path::new("Dockerfile").exists() && !image.trim().is_empty())
+}
+
+fn release_is_complete(
+    crate_published: bool,
+    dockerhub_required: bool,
+    dockerhub_published: bool,
+    github_release_published: bool,
+) -> bool {
+    crate_published && (!dockerhub_required || dockerhub_published) && github_release_published
 }
 
 fn parse_semver(version: &str) -> Option<(u32, u32, u32)> {
@@ -139,11 +239,17 @@ fn get_max_published_version(crate_name: &str) -> Option<String> {
                                 if let Some(parsed) = parse_semver(&v.num) {
                                     match &max_version {
                                         None => {
-                                            max_version = Some((parsed.0, parsed.1, parsed.2, v.num.clone()));
+                                            max_version =
+                                                Some((parsed.0, parsed.1, parsed.2, v.num.clone()));
                                         }
                                         Some(current) => {
                                             if parsed > (current.0, current.1, current.2) {
-                                                max_version = Some((parsed.0, parsed.1, parsed.2, v.num.clone()));
+                                                max_version = Some((
+                                                    parsed.0,
+                                                    parsed.1,
+                                                    parsed.2,
+                                                    v.num.clone(),
+                                                ));
                                             }
                                         }
                                     }
@@ -205,22 +311,77 @@ fn main() {
     }
 
     if !has_fragments {
-        let is_published = check_version_on_crates_io(&crate_name, &current_version);
+        let crate_published = check_version_on_crates_io(&crate_name, &current_version);
+        let tag_prefix = get_arg("tag-prefix").unwrap_or_else(|| "v".to_string());
+        let dockerhub_image = docker_hub_image_to_check();
+        let dockerhub_required = dockerhub_image.is_some();
+        let dockerhub_published = dockerhub_image
+            .as_deref()
+            .map(|image| {
+                check_docker_hub_tag(image, &current_version)
+                    && check_docker_hub_tag(image, "latest")
+            })
+            .unwrap_or(false);
+        let github_release_published = get_arg("repository")
+            .or_else(|| env::var("GITHUB_REPOSITORY").ok().filter(|s| !s.is_empty()))
+            .map(|repository| check_github_release(&repository, &tag_prefix, &current_version))
+            .unwrap_or_else(|| {
+                eprintln!("Warning: GITHUB_REPOSITORY not set; assuming GitHub release is missing");
+                false
+            });
+
+        set_output(
+            "crate_published",
+            if crate_published { "true" } else { "false" },
+        );
+        set_output(
+            "dockerhub_required",
+            if dockerhub_required { "true" } else { "false" },
+        );
+        set_output(
+            "dockerhub_published",
+            if dockerhub_published { "true" } else { "false" },
+        );
+        set_output(
+            "github_release_published",
+            if github_release_published {
+                "true"
+            } else {
+                "false"
+            },
+        );
 
         println!(
             "Crate: {}, Version: {}, Published on crates.io: {}",
-            crate_name, current_version, is_published
+            crate_name, current_version, crate_published
+        );
+        if let Some(image) = dockerhub_image {
+            println!(
+                "Docker image: {}, version/latest tags published on Docker Hub: {}",
+                image, dockerhub_published
+            );
+        } else {
+            println!("Docker Hub artifact check skipped: DOCKERHUB_IMAGE or Dockerfile is not configured");
+        }
+        println!(
+            "GitHub release {}{} published: {}",
+            tag_prefix, current_version, github_release_published
         );
 
-        if is_published {
+        if release_is_complete(
+            crate_published,
+            dockerhub_required,
+            dockerhub_published,
+            github_release_published,
+        ) {
             println!(
-                "No changelog fragments and v{} already published on crates.io",
+                "No changelog fragments and v{} is fully published",
                 current_version
             );
             set_output("should_release", "false");
         } else {
             println!(
-                "No changelog fragments but v{} not yet published to crates.io",
+                "No changelog fragments but v{} is missing at least one release artifact",
                 current_version
             );
             set_output("should_release", "true");

--- a/scripts/create-github-release.rs
+++ b/scripts/create-github-release.rs
@@ -4,7 +4,7 @@
 //! Automatically includes crates.io and docs.rs badges in release notes
 //! when the crate name can be detected from Cargo.toml.
 //!
-//! Usage: rust-script scripts/create-github-release.rs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <name>] [--release-label <label>]
+//! Usage: rust-script scripts/create-github-release.rs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <name>] [--release-label <label>] [--docker-hub-url <url>]
 //!
 //! ```cargo
 //! [dependencies]
@@ -28,7 +28,7 @@ use std::path::Path;
 use std::process::{exit, Command, Stdio};
 
 #[cfg(not(test))]
-const USAGE: &str = "Usage: rust-script scripts/create-github-release.rs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <name>] [--release-label <label>]";
+const USAGE: &str = "Usage: rust-script scripts/create-github-release.rs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <name>] [--release-label <label>] [--docker-hub-url <url>]";
 
 #[cfg(not(test))]
 fn get_rust_root() -> String {
@@ -129,6 +129,39 @@ fn build_release_name(
     }
 }
 
+fn badge_escape(value: &str) -> String {
+    value
+        .replace('-', "--")
+        .replace('_', "__")
+        .replace(' ', "%20")
+        .replace('/', "%2F")
+        .replace(':', "%3A")
+        .replace('+', "%2B")
+}
+
+fn docker_hub_tag_query(version: &str) -> String {
+    version.replace('+', "%2B")
+}
+
+fn docker_hub_badge(url: &str, version: &str) -> String {
+    let trimmed_url = url.trim_end_matches('/');
+    let image = trimmed_url
+        .strip_prefix("https://hub.docker.com/r/")
+        .unwrap_or(trimmed_url);
+    let image_tag = format!("{image}:{version}");
+    let tag_url = format!(
+        "{}/tags?name={}",
+        trimmed_url,
+        docker_hub_tag_query(version)
+    );
+
+    format!(
+        "[![Docker Hub](https://img.shields.io/badge/docker-{}-2496ED?logo=docker)]({})",
+        badge_escape(&image_tag),
+        tag_url
+    )
+}
+
 #[cfg(not(test))]
 fn get_changelog_for_version(version: &str) -> String {
     let changelog_path = "CHANGELOG.md";
@@ -217,6 +250,7 @@ fn main() {
     let language = get_arg("language").unwrap_or_else(|| "Rust".to_string());
     let release_label = get_arg("release-label");
     let crates_io_url = get_arg("crates-io-url");
+    let docker_hub_url = get_arg("docker-hub-url");
     let normalized_version = normalize_release_version(&version);
 
     let rust_root = get_rust_root();
@@ -233,11 +267,18 @@ fn main() {
     }
 
     let mut release_notes = get_changelog_for_version(&normalized_version);
+    let mut badges = Vec::new();
     if let Some(crate_name) = get_crate_name_from_toml(&cargo_toml) {
-        let badges = format!(
+        let crate_badges = format!(
             "[![Crates.io](https://img.shields.io/crates/v/{crate_name}?label=crates.io)](https://crates.io/crates/{crate_name}/{normalized_version}) [![Docs.rs](https://docs.rs/{crate_name}/badge.svg)](https://docs.rs/{crate_name}/{normalized_version})"
         );
-        release_notes = format!("{badges}\n\n{release_notes}");
+        badges.push(crate_badges);
+    }
+    if let Some(url) = docker_hub_url {
+        badges.push(docker_hub_badge(&url, &normalized_version));
+    }
+    if !badges.is_empty() {
+        release_notes = format!("{}\n\n{release_notes}", badges.join(" "));
     }
 
     if let Some(url) = crates_io_url {
@@ -352,5 +393,21 @@ mod tests {
                 body: "release notes".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn docker_hub_badge_links_to_exact_tag() {
+        let badge = docker_hub_badge("https://hub.docker.com/r/example/project", "1.2.3");
+
+        assert!(badge.contains("docker-example%2Fproject%3A1.2.3"));
+        assert!(badge.contains("https://hub.docker.com/r/example/project/tags?name=1.2.3"));
+    }
+
+    #[test]
+    fn docker_hub_badge_escapes_build_metadata() {
+        let badge = docker_hub_badge("https://hub.docker.com/r/example/project", "1.2.3+build.4");
+
+        assert!(badge.contains("1.2.3%2Bbuild.4"));
+        assert!(badge.contains("tags?name=1.2.3%2Bbuild.4"));
     }
 }

--- a/scripts/get-version.rs
+++ b/scripts/get-version.rs
@@ -18,6 +18,7 @@
 //! regex = "1"
 //! ```
 
+use std::env;
 use std::fs;
 use std::process::exit;
 

--- a/scripts/wait-for-crate.rs
+++ b/scripts/wait-for-crate.rs
@@ -1,0 +1,178 @@
+#!/usr/bin/env rust-script
+//! Wait for a crates.io package version to become visible.
+//!
+//! The Docker release step runs after `cargo publish`, but crates.io indexing can
+//! lag briefly. Waiting here makes Docker Hub tags and GitHub releases point at a
+//! crate version that users can already resolve.
+//!
+//! Usage:
+//!   rust-script scripts/wait-for-crate.rs --release-version <version>
+//!
+//! Optional arguments:
+//!   --crate-name <name>       Crate name. Defaults to Cargo.toml package name.
+//!   --rust-root <path>        Root containing Cargo.toml. Defaults to auto-detect.
+//!   --max-attempts <count>    Defaults to 30.
+//!   --sleep-seconds <count>   Defaults to 10.
+//!
+//! Outputs (written to GITHUB_OUTPUT):
+//!   - crate_available: 'true' when the version is visible, or 'skipped' for template defaults
+//!
+//! ```cargo
+//! [dependencies]
+//! regex = "1"
+//! ureq = "2"
+//! ```
+
+use std::env;
+use std::fs;
+use std::process::exit;
+use std::thread;
+use std::time::Duration;
+
+#[path = "rust-paths.rs"]
+mod rust_paths;
+
+fn get_arg(name: &str) -> Option<String> {
+    let args: Vec<String> = env::args().collect();
+    let flag = format!("--{}", name);
+
+    if let Some(idx) = args.iter().position(|a| a == &flag) {
+        return args.get(idx + 1).cloned();
+    }
+
+    let env_name = name.to_uppercase().replace('-', "_");
+    env::var(&env_name).ok().filter(|s| !s.is_empty())
+}
+
+fn set_output(key: &str, value: &str) {
+    if let Ok(output_file) = env::var("GITHUB_OUTPUT") {
+        if let Err(e) = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&output_file)
+            .and_then(|mut f| {
+                use std::io::Write;
+                writeln!(f, "{}={}", key, value)
+            })
+        {
+            eprintln!("Warning: Could not write to GITHUB_OUTPUT: {}", e);
+        }
+    }
+    println!("Output: {}={}", key, value);
+}
+
+fn parse_count_arg(name: &str, default: u64) -> u64 {
+    get_arg(name)
+        .and_then(|value| {
+            value.parse::<u64>().map_or_else(
+                |_| {
+                    eprintln!(
+                        "Warning: Invalid {} value '{}'; using default {}",
+                        name, value, default
+                    );
+                    None
+                },
+                Some,
+            )
+        })
+        .unwrap_or(default)
+}
+
+fn crate_version_exists(crate_name: &str, version: &str) -> bool {
+    let url = format!("https://crates.io/api/v1/crates/{}/{}", crate_name, version);
+
+    match ureq::get(&url)
+        .set("User-Agent", "rust-script-wait-for-crate")
+        .call()
+    {
+        Ok(response) => response.status() == 200,
+        Err(ureq::Error::Status(404, _)) => false,
+        Err(e) => {
+            eprintln!("Warning: Could not check crates.io: {}", e);
+            false
+        }
+    }
+}
+
+fn should_skip_crate_wait(crate_name: &str) -> bool {
+    crate_name == "example-sum-package-name"
+}
+
+fn main() {
+    let rust_root = match rust_paths::get_rust_root(None, true) {
+        Ok(root) => root,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
+    };
+    let cargo_toml = rust_paths::get_cargo_toml_path(&rust_root);
+    let package_manifest = match rust_paths::get_package_manifest_path(&cargo_toml) {
+        Ok(path) => path,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
+    };
+    let package_info = match rust_paths::read_package_info(&package_manifest) {
+        Ok(info) => info,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
+    };
+
+    let crate_name = get_arg("crate-name").unwrap_or(package_info.name);
+    let version = get_arg("release-version").unwrap_or(package_info.version);
+    let max_attempts = parse_count_arg("max-attempts", 30);
+    let sleep_seconds = parse_count_arg("sleep-seconds", 10);
+
+    if should_skip_crate_wait(&crate_name) {
+        println!(
+            "Skipping crates.io availability wait: package name is the template default '{}'",
+            crate_name
+        );
+        set_output("crate_available", "skipped");
+        return;
+    }
+
+    for attempt in 1..=max_attempts {
+        if crate_version_exists(&crate_name, &version) {
+            println!(
+                "{}@{} is visible on crates.io after attempt {}",
+                crate_name, version, attempt
+            );
+            set_output("crate_available", "true");
+            return;
+        }
+
+        if attempt < max_attempts {
+            println!(
+                "{}@{} is not visible on crates.io yet (attempt {}/{}); waiting {}s",
+                crate_name, version, attempt, max_attempts, sleep_seconds
+            );
+            thread::sleep(Duration::from_secs(sleep_seconds));
+        }
+    }
+
+    eprintln!(
+        "Error: {}@{} was not visible on crates.io after {} attempts",
+        crate_name, version, max_attempts
+    );
+    exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_skip_crate_wait;
+
+    #[test]
+    fn skips_template_default_package_name() {
+        assert!(should_skip_crate_wait("example-sum-package-name"));
+    }
+
+    #[test]
+    fn waits_for_real_package_names() {
+        assert!(!should_skip_crate_wait("real-package-name"));
+    }
+}

--- a/tests/unit/ci-cd/workflow_release.rs
+++ b/tests/unit/ci-cd/workflow_release.rs
@@ -93,3 +93,125 @@ fn release_workflow_jobs_have_explicit_timeouts() {
         );
     }
 }
+
+#[test]
+fn release_workflow_publishes_optional_docker_hub_image_after_crate_is_visible() {
+    let workflow = release_workflow();
+
+    assert!(
+        workflow.contains("DOCKERHUB_IMAGE: ${{ vars.DOCKERHUB_IMAGE }}"),
+        "workflow should expose an opt-in Docker Hub image variable"
+    );
+    assert_eq!(
+        workflow.matches("docker/login-action@v4").count(),
+        2,
+        "auto and manual release jobs should log in to Docker Hub when configured"
+    );
+    assert_eq!(
+        workflow.matches("docker/metadata-action@v6").count(),
+        2,
+        "auto and manual release jobs should derive Docker tags for Docker Hub"
+    );
+    assert_eq!(
+        workflow.matches("docker/build-push-action@v7").count(),
+        2,
+        "auto and manual release jobs should publish Docker Hub images when configured"
+    );
+    assert!(
+        workflow.contains("password: ${{ env.DOCKERHUB_TOKEN }}"),
+        "Docker Hub login should use DOCKERHUB_TOKEN"
+    );
+
+    let auto_release = job_block(&workflow, "auto-release");
+    let auto_publish = auto_release
+        .find("- name: Publish to Crates.io")
+        .expect("auto release should publish the crate");
+    let auto_wait = auto_release
+        .find("- name: Wait for Crate availability on Crates.io")
+        .expect("auto release should wait for the crate");
+    let auto_docker = auto_release
+        .find("- name: Publish Docker image to Docker Hub")
+        .expect("auto release should publish the Docker image");
+    let auto_github_release = auto_release
+        .find("- name: Create GitHub Release")
+        .expect("auto release should create a GitHub release");
+
+    assert!(
+        auto_publish < auto_wait && auto_wait < auto_docker && auto_docker < auto_github_release,
+        "auto release should publish crates.io first, then Docker Hub, then GitHub release"
+    );
+
+    let manual_release = job_block(&workflow, "manual-release");
+    let manual_publish = manual_release
+        .find("- name: Publish to Crates.io")
+        .expect("manual release should publish the crate");
+    let manual_wait = manual_release
+        .find("- name: Wait for Crate availability on Crates.io")
+        .expect("manual release should wait for the crate");
+    let manual_docker = manual_release
+        .find("- name: Publish Docker image to Docker Hub")
+        .expect("manual release should publish the Docker image");
+    let manual_github_release = manual_release
+        .find("- name: Create GitHub Release")
+        .expect("manual release should create a GitHub release");
+
+    assert!(
+        manual_publish < manual_wait
+            && manual_wait < manual_docker
+            && manual_docker < manual_github_release,
+        "manual release should publish crates.io first, then Docker Hub, then GitHub release"
+    );
+}
+
+#[test]
+fn release_scripts_check_configured_release_artifacts() {
+    let release_check = fs::read_to_string(format!(
+        "{}/scripts/check-release-needed.rs",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .unwrap();
+    let wait_for_crate = fs::read_to_string(format!(
+        "{}/scripts/wait-for-crate.rs",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .unwrap();
+    let release_script = fs::read_to_string(format!(
+        "{}/scripts/create-github-release.rs",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .unwrap();
+
+    assert!(
+        release_check.contains("check_docker_hub_tag"),
+        "release-needed check should verify configured Docker Hub tags"
+    );
+    assert!(
+        release_check.contains("check_docker_hub_tag(image, \"latest\")"),
+        "release-needed check should verify Docker Hub latest tags as part of completeness"
+    );
+    assert!(
+        release_check.contains("check_github_release"),
+        "release-needed check should verify GitHub release artifacts"
+    );
+    assert!(
+        release_check.contains("crate_published"),
+        "release-needed check should output whether the crate already exists"
+    );
+    assert!(
+        wait_for_crate.contains("crates.io/api/v1/crates"),
+        "release workflow should wait for crates.io visibility before image publishing"
+    );
+    assert!(
+        wait_for_crate.contains("example-sum-package-name")
+            && wait_for_crate.contains("crate_available\", \"skipped\""),
+        "crate availability wait should preserve template-safe publishing skips"
+    );
+    assert!(
+        release_script.contains("--docker-hub-url"),
+        "GitHub release creation should accept a Docker Hub URL"
+    );
+    assert!(
+        release_script.contains("fn docker_hub_badge"),
+        "GitHub release notes should include Docker Hub badge support"
+    );
+}


### PR DESCRIPTION
Closes #46

## Summary
- Adds optional Docker Hub publishing to the auto and manual release jobs using Docker official GitHub Actions.
- Gates image publishing on a configured `DOCKERHUB_IMAGE`, root `Dockerfile`, `DOCKERHUB_USERNAME`, and `DOCKERHUB_TOKEN`.
- Waits for the matching crates.io version before publishing Docker Hub `latest` and version tags.
- Extends release completeness checks so reruns can self-heal missing GitHub release or configured Docker Hub tags without bumping/publishing the crate again.
- Adds Docker Hub badge support for GitHub release notes and documents repository configuration.

## Tests
- `cargo test --test unit -- --nocapture`
- `RUSTFLAGS=-Dwarnings cargo test --all-features --verbose`
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets --all-features`
- `RUSTFLAGS=-Dwarnings cargo build --release --verbose`
- `cargo package --list --allow-dirty`
- `RUST_LOG=error rust-script scripts/check-file-size.rs`
- `RUST_LOG=error rust-script scripts/check-release-needed.rs`
- `RUST_LOG=error rust-script scripts/wait-for-crate.rs --crate-name serde --release-version 1.0.228 --max-attempts 1 --sleep-seconds 0`
- YAML parse check for `.github/workflows/release.yml`
