### PR TITLE
fix: deploy docs with GitHub Pages artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -625,7 +625,9 @@ jobs:
   # === DEPLOY DOCUMENTATION ===
   # Deploy Rust API documentation to GitHub Pages after a successful package build.
   # Keep this independent from package/GitHub release publication so the website
-  # still updates when the release path fails.
+  # still updates when the release path fails. Use the official Pages artifact
+  # deployment path so repositories configured with "GitHub Actions" as their
+  # Pages source fail this job if Pages cannot deploy.
   deploy-docs:
     name: Deploy Rust Documentation
     needs: [build]
@@ -638,7 +640,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: write
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -650,8 +657,14 @@ jobs:
       - name: Build documentation
         run: cargo doc --no-deps --all-features
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: target/doc
+          path: target/doc
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-12T17:24:55.327Z for PR creation at branch issue-48-d243c5c85fe9 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/48

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-12T17:24:55.327Z for PR creation at branch issue-48-d243c5c85fe9 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/48

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "example-sum-package-name"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "clap",
  "lino-arguments",

--- a/changelog.d/20260512_172908_github_pages_artifact_deploy.md
+++ b/changelog.d/20260512_172908_github_pages_artifact_deploy.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Switched documentation deployment to the official GitHub Pages artifact workflow so repositories using GitHub Actions as their Pages source do not get false-positive branch-push deploys.

--- a/tests/unit/ci-cd/workflow_release.rs
+++ b/tests/unit/ci-cd/workflow_release.rs
@@ -61,6 +61,27 @@ fn documentation_deploy_is_independent_from_release_publication() {
 }
 
 #[test]
+fn documentation_deploy_uses_github_pages_artifact_flow() {
+    let workflow = release_workflow();
+    let deploy_docs = job_block(&workflow, "deploy-docs");
+
+    assert!(deploy_docs.contains("contents: read"));
+    assert!(deploy_docs.contains("pages: write"));
+    assert!(deploy_docs.contains("id-token: write"));
+    assert!(deploy_docs.contains("environment:"));
+    assert!(deploy_docs.contains("name: github-pages"));
+    assert!(deploy_docs.contains("url: ${{ steps.deployment.outputs.page_url }}"));
+    assert!(deploy_docs.contains("uses: actions/configure-pages@v6"));
+    assert!(deploy_docs.contains("uses: actions/upload-pages-artifact@v5"));
+    assert!(deploy_docs.contains("path: target/doc"));
+    assert!(deploy_docs.contains("id: deployment"));
+    assert!(deploy_docs.contains("uses: actions/deploy-pages@v5"));
+    assert!(!deploy_docs.contains("contents: write"));
+    assert!(!deploy_docs.contains("peaceiris/actions-gh-pages"));
+    assert!(!deploy_docs.contains("publish_dir: target/doc"));
+}
+
+#[test]
 fn release_workflow_jobs_have_explicit_timeouts() {
     let workflow = release_workflow();
     let expected_timeouts = [


### PR DESCRIPTION
Fixes #48.

## Summary

- Replace the branch-push `peaceiris/actions-gh-pages` documentation deploy with the official GitHub Pages artifact flow.
- Grant `deploy-docs` `contents: read`, `pages: write`, and `id-token: write`, and publish the deployment URL through the `github-pages` environment.
- Add a workflow regression test that fails if docs deployment returns to branch publishing or drops the Pages artifact steps.
- Add a changelog fragment, remove the generated PR placeholder `.gitkeep`, and sync the root package version in `Cargo.lock` with `Cargo.toml` after running Cargo.

## Reproduction

The new regression test failed before the workflow fix because `deploy-docs` used `peaceiris/actions-gh-pages` with `publish_dir: target/doc` and did not have GitHub Pages artifact permissions.

This matches the downstream failure mode from #48: a repository configured with Pages source set to GitHub Actions can accept a successful `gh-pages` branch push without creating the configured Pages deployment.

## Verification

- `cargo test --test unit ci_cd::workflow_release::documentation_deploy_uses_github_pages_artifact_flow` (failed before the workflow change, passes after)
- `cargo fmt --all -- --check`
- `rust-script scripts/check-file-size.rs`
- `RUSTFLAGS=-Dwarnings cargo test --all-features --verbose`
- `RUSTFLAGS=-Dwarnings cargo test --doc --verbose`
- `cargo clippy --all-targets --all-features`
- `RUSTFLAGS=-Dwarnings cargo build --release --verbose`
- `cargo package --list --allow-dirty`
