### PR TITLE
docs: document one-time GitHub Pages source prerequisite for deploy-docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -628,6 +628,11 @@ jobs:
   # still updates when the release path fails. Use the official Pages artifact
   # deployment path so repositories configured with "GitHub Actions" as their
   # Pages source fail this job if Pages cannot deploy.
+  #
+  # One-time setup: in the repository's Settings -> Pages, set Source to
+  # "GitHub Actions". Without this, the first run fails on actions/deploy-pages
+  # with "Get Pages site failed" / "Failed to create deployment". This cannot be
+  # configured from a workflow. See README.md "Deploying API documentation".
   deploy-docs:
     name: Deploy Rust Documentation
     needs: [build]

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-12T22:59:34.075Z for PR creation at branch issue-50-f6272907aac6 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/50

--- a/README.md
+++ b/README.md
@@ -254,6 +254,14 @@ Add a visible Docker Hub badge next to the crates.io badge in repositories that 
 [![Docker Hub](https://img.shields.io/docker/v/my-dockerhub-user/my-image?label=docker%20hub)](https://hub.docker.com/r/my-dockerhub-user/my-image)
 ```
 
+## Deploying API documentation
+
+The `deploy-docs` job in `.github/workflows/release.yml` publishes `cargo doc --no-deps --all-features` output to GitHub Pages on every push to `main` and on `workflow_dispatch` with `release_mode == 'instant'`. It uses the official `actions/configure-pages` / `actions/upload-pages-artifact` / `actions/deploy-pages` flow, which requires the repository's Pages source to be set to **GitHub Actions**.
+
+Before the first run on `main`, open **Settings → Pages** of the new repository and set **Source = GitHub Actions**. This is a one-time manual step and cannot be configured from a workflow. The `deploy-docs` job will then provision the Pages site on its first run.
+
+If this step is skipped, the first `deploy-docs` run fails on `actions/deploy-pages@v5` with `Error: Get Pages site failed.` / `Error: Failed to create deployment`. Flip the Pages source as described above and re-run the failed job; no workflow changes are required.
+
 ## Scripts Reference
 
 All scripts in `scripts/` are Rust scripts that use [rust-script](https://github.com/fornwall/rust-script).

--- a/changelog.d/20260512_230053_document_pages_source_prerequisite.md
+++ b/changelog.d/20260512_230053_document_pages_source_prerequisite.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Added
+- Documented the one-time `Settings → Pages → Source = GitHub Actions` prerequisite for the `deploy-docs` job in `README.md` and as a comment above the `deploy-docs` job in `release.yml`, so downstream template users hit a documented setup step instead of a `Get Pages site failed` error on the first deploy.


### PR DESCRIPTION
## Summary

Fixes #50. The `deploy-docs` job in `release.yml` publishes `cargo doc` output to GitHub Pages on push to `main` (and on `workflow_dispatch` with `release_mode == 'instant'`), but the first time a downstream repository runs it, the deploy job fails with `Error: Get Pages site failed.` / `Error: Failed to create deployment` if **Settings → Pages → Source** is not set to **GitHub Actions** (it defaults to *Deploy from a branch*). This cannot be automated from inside a workflow.

This affected [link-foundation/relative-meta-logic#163](https://github.com/link-foundation/relative-meta-logic/issues/163) (fixed in [PR #170](https://github.com/link-foundation/relative-meta-logic/pull/170)) — the workflow rewrite was necessary but not sufficient; the maintainer also had to flip the Pages source.

## Changes

- **`README.md`** — new top-level `## Deploying API documentation` section that:
  - Explains which deploy trigger the `deploy-docs` job uses and that it relies on the GitHub Actions Pages flow.
  - Instructs the maintainer to set **Settings → Pages → Source = GitHub Actions** as a one-time manual step before the first run on `main`.
  - Documents the exact error (`Error: Get Pages site failed.` / `Error: Failed to create deployment`) that this prerequisite prevents, so future searches land on a documented step rather than on the case study in `relative-meta-logic`.
- **`.github/workflows/release.yml`** — extended the comment block above the `deploy-docs` job with the same one-time setup note, pointing readers at the `README.md` section. No workflow logic was changed.
- **`changelog.d/20260512_230053_document_pages_source_prerequisite.md`** — patch-bump changelog fragment under `### Added`.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` parses the updated workflow.
- [x] `git diff` shows only docs/changelog changes: 13 inserted lines in `README.md` + `release.yml`, plus the new changelog fragment.
- [x] README section text matches the wording requested in the issue.
- [ ] Manual verification on a fresh fork: bootstrap a repo from this template, push to `main` without touching repository settings, observe `deploy-docs` failing on `actions/deploy-pages@v5` with `Get Pages site failed`; then follow the new README section, re-run, and confirm the deploy succeeds. (Cannot be automated from CI on the template repo itself, which already has Pages configured.)