### PR TITLE
fix(ci): correct reversed cancel-in-progress condition in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-12T22:59:34.075Z for PR creation at branch issue-50-f6272907aac6 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/50
+# Updated: 2026-05-29T20:51:50.023Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-05-12T22:59:34.075Z for PR creation at branch issue-50-f6272907aac6 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/50
-# Updated: 2026-05-29T20:51:50.023Z

--- a/changelog.d/20260529_205200_fix_cancel_in_progress_condition.md
+++ b/changelog.d/20260529_205200_fix_cancel_in_progress_condition.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Fixed reversed `cancel-in-progress` concurrency condition in `release.yml` that cancelled in-flight releases on `main` and never superseded older PR runs. The condition now uses `!=` so `main` releases run to completion while newer PR pushes cancel stale runs.


### PR DESCRIPTION
## Summary

Fixes #56.

`release.yml` used a reversed `cancel-in-progress` concurrency condition:

```yaml
cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
```

With `==`, the value was `true` on `main` and `false` on PR branches — the opposite of the intent:

- **On `main`** a new push (e.g. an automated data/currency update or a follow-up commit landing while a release was in flight) **cancelled** the running release pipeline, risking a half-published release (crates.io published but no GitHub Release, or vice-versa).
- **On PR branches** every push started a new run racing the previous one, wasting CI minutes and clogging the runner queue.

## Fix

```yaml
cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

Now `main` releases run to completion (never cancelled by a concurrent push), while newer PR pushes supersede older still-running runs.

## Changes
- `.github/workflows/release.yml`: `==` → `!=` on the `cancel-in-progress` line.
- `changelog.d/`: added a patch-bump changelog fragment.

## Verification
This is a GitHub Actions concurrency expression. The behavior is determined by the `${{ ... }}` expression evaluation:
- `github.ref == 'refs/heads/main'` → `true` on main, `false` elsewhere (old, reversed).
- `github.ref != 'refs/heads/main'` → `false` on main, `true` elsewhere (correct intent: protect main, supersede PR runs).
