### PR TITLE
Add a crates.io package size guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,6 +267,9 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install rust-script
+        run: cargo install rust-script
+
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:
@@ -283,6 +286,9 @@ jobs:
 
       - name: Check package
         run: cargo package --list --allow-dirty
+
+      - name: Check crate package size
+        run: rust-script scripts/check-crate-size.rs
 
   # === AUTO RELEASE ===
   # Automatic release on push to main using changelog fragments
@@ -344,6 +350,10 @@ jobs:
       - name: Build release
         if: steps.check.outputs.should_release == 'true'
         run: cargo build --release
+
+      - name: Check crate package size
+        if: steps.check.outputs.should_release == 'true' && steps.check.outputs.crate_published != 'true'
+        run: rust-script scripts/check-crate-size.rs
 
       - name: Publish to Crates.io
         if: steps.check.outputs.should_release == 'true' && steps.check.outputs.crate_published != 'true'
@@ -485,6 +495,10 @@ jobs:
       - name: Build release
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         run: cargo build --release
+
+      - name: Check crate package size
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        run: rust-script scripts/check-crate-size.rs
 
       - name: Publish to Crates.io
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-05-12T22:59:34.075Z for PR creation at branch issue-50-f6272907aac6 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/50
-# Updated: 2026-05-29T20:52:18.110Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-12T22:59:34.075Z for PR creation at branch issue-50-f6272907aac6 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/50
+# Updated: 2026-05-29T20:52:18.110Z

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,18 @@ repository = "https://github.com/link-foundation/rust-ai-driven-development-pipe
 documentation = "https://github.com/link-foundation/rust-ai-driven-development-pipeline-template"
 rust-version = "1.70"
 
+# Narrow allowlist of files shipped in the published `.crate` archive.
+# Keeping this list tight prevents docs, case studies, generated CI artifacts,
+# changelog fragments, and experiments from silently inflating the release
+# archive past the crates.io 10 MiB upload limit. See issue #58.
+include = [
+    "src/**/*.rs",
+    "examples/**/*.rs",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+]
+
 [lib]
 name = "example_sum_package_name"
 path = "src/lib.rs"

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ cargo clippy --all-targets --all-features
 # Check file size limits (requires rust-script: cargo install rust-script)
 rust-script scripts/check-file-size.rs
 
+# Check the packaged crate stays under the crates.io 10 MiB upload limit
+rust-script scripts/check-crate-size.rs
+
 # Run all checks
 cargo fmt --check && cargo clippy --all-targets --all-features && rust-script scripts/check-file-size.rs
 ```
@@ -113,6 +116,7 @@ cargo fmt --check && cargo clippy --all-targets --all-features && rust-script sc
 ├── scripts/                        # Rust scripts (via rust-script)
 │   ├── bump-version.rs             # Version bumping utility
 │   ├── check-changelog-fragment.rs # Changelog fragment validation
+│   ├── check-crate-size.rs         # Crate archive size guard (crates.io 10 MiB limit)
 │   ├── check-file-size.rs          # File size validation script
 │   ├── check-release-needed.rs     # Release necessity check
 │   ├── check-version-modification.rs # Version modification detection
@@ -275,6 +279,7 @@ Install rust-script with: `cargo install rust-script`
 | `cargo run -- --a 3 --b 7`           | Run CLI (sum 3 + 7)     |
 | `cargo run --example basic_usage`     | Run example              |
 | `rust-script scripts/check-file-size.rs` | Check file size limits |
+| `rust-script scripts/check-crate-size.rs` | Check crate archive size (crates.io 10 MiB limit) |
 | `rust-script scripts/bump-version.rs` | Bump version             |
 
 ## Example Usage

--- a/changelog.d/20260529_205500_crate_package_size_guard.md
+++ b/changelog.d/20260529_205500_crate_package_size_guard.md
@@ -1,0 +1,9 @@
+---
+bump: minor
+---
+
+### Added
+- Added a `scripts/check-crate-size.rs` guard that builds the `.crate` archive and fails the release before publishing when it exceeds the crates.io 10 MiB upload limit. The check runs in the build job and before publishing in both the auto-release and manual-release jobs.
+
+### Changed
+- Added a narrow `include` allowlist to `Cargo.toml` so docs, case studies, generated CI artifacts, changelog fragments, scripts, and experiments no longer inflate the published release archive.

--- a/docs/ci-cd/troubleshooting.md
+++ b/docs/ci-cd/troubleshooting.md
@@ -7,9 +7,10 @@ This guide covers common CI/CD issues and their solutions for Rust projects usin
 1. [Release Jobs Skipped](#release-jobs-skipped)
 2. [Version Already Released (False Positive)](#version-already-released-false-positive)
 3. [Crates.io Publishing Fails](#cratesio-publishing-fails)
-4. [Docker Hub Publishing Fails](#docker-hub-publishing-fails)
-5. [Secret Configuration Issues](#secret-configuration-issues)
-6. [Multi-Language Repository Issues](#multi-language-repository-issues)
+4. [Crate Package Too Large (HTTP 413)](#crate-package-too-large-http-413)
+5. [Docker Hub Publishing Fails](#docker-hub-publishing-fails)
+6. [Secret Configuration Issues](#secret-configuration-issues)
+7. [Multi-Language Repository Issues](#multi-language-repository-issues)
 
 ---
 
@@ -113,6 +114,64 @@ The "Publish to Crates.io" step fails with an error.
 ### Reference
 - [browser-commander Issue #33](https://github.com/link-foundation/browser-commander/issues/33)
 - [Cargo Publishing Documentation](https://doc.rust-lang.org/cargo/reference/publishing.html)
+
+---
+
+## Crate Package Too Large (HTTP 413)
+
+### Symptom
+`cargo publish` is rejected by crates.io with:
+
+```
+error: failed to publish to registry
+the remote server responded with an error (status 413 Payload Too Large):
+max upload size is 10485760
+```
+
+### Root Cause
+The generated `.crate` archive exceeds the crates.io upload limit of **10 MiB
+(10485760 bytes)**. This usually happens when documentation, case studies,
+generated CI artifacts, datasets, or experiment files are silently bundled into
+the package.
+
+### How This Template Prevents It
+
+#### 1. Pre-publish size guard
+`scripts/check-crate-size.rs` builds the `.crate` archive and fails the workflow
+**before** publishing when the archive is over the limit. It runs in the `build`
+job (early PR feedback) and again right before the publish step in both the
+`auto-release` and `manual-release` jobs.
+
+Run it locally before pushing:
+```bash
+rust-script scripts/check-crate-size.rs
+```
+
+#### 2. Narrow `include` allowlist
+`Cargo.toml` declares an `include` list so only the crate sources and a few
+documentation files ship in the release archive:
+```toml
+include = [
+    "src/**/*.rs",
+    "examples/**/*.rs",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+]
+```
+
+### Solution When the Guard Fails
+1. Inspect what is being packaged:
+   ```bash
+   cargo package --list --allow-dirty
+   ```
+2. Tighten the `include` allowlist in `Cargo.toml` (or add an `exclude` list) to
+   drop large files such as docs, datasets, generated logs, and experiments.
+3. Re-run the size guard to confirm the archive is under 10 MiB.
+
+### Reference
+- [Cargo `include`/`exclude` fields](https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields)
+- [Cargo packaging documentation](https://doc.rust-lang.org/cargo/reference/publishing.html#packaging-a-crate)
 
 ---
 
@@ -255,4 +314,5 @@ cargo fmt --all -- --check
 cargo clippy --all-targets --all-features
 cargo test --all-features
 cargo package --list
+rust-script scripts/check-crate-size.rs
 ```

--- a/scripts/check-crate-size.rs
+++ b/scripts/check-crate-size.rs
@@ -1,0 +1,262 @@
+#!/usr/bin/env rust-script
+//! Check the packaged `.crate` archive against the crates.io upload limit
+//!
+//! crates.io rejects `cargo publish` uploads larger than 10 MiB (10485760 bytes)
+//! with an HTTP 413 error. This guard runs `cargo package` to build the archive
+//! and fails the release before publishing when the archive is too large, so the
+//! release pipeline surfaces a clear, actionable error instead of a late 413.
+//!
+//! Supports both single-language and multi-language repository structures:
+//! - Single-language: Cargo.toml in repository root
+//! - Multi-language: Cargo.toml in rust/ subfolder
+//!
+//! Usage: rust-script scripts/check-crate-size.rs [--rust-root <path>]
+//!
+//! Outputs (written to `GITHUB_OUTPUT`):
+//!   - `crate_size_bytes`: size of the generated `.crate` archive in bytes
+//!   - `crate_size_check`: 'pass' or 'fail'
+//!
+//! Reference: <https://doc.rust-lang.org/cargo/reference/publishing.html#packaging-a-crate>
+//!
+//! ```cargo
+//! [dependencies]
+//! regex = "1"
+//! ```
+
+#[cfg(not(test))]
+use std::env;
+use std::fs;
+#[cfg(not(test))]
+use std::io::Write;
+use std::path::{Path, PathBuf};
+#[cfg(not(test))]
+use std::process::{exit, Command};
+
+#[cfg(not(test))]
+#[path = "rust-paths.rs"]
+mod rust_paths;
+
+/// crates.io hard upload limit for a `.crate` archive (10 MiB).
+/// See <https://doc.rust-lang.org/cargo/reference/publishing.html#packaging-a-crate>
+const MAX_CRATE_BYTES: u64 = 10 * 1024 * 1024;
+/// Warn once the archive grows past 80% of the limit so projects can react
+/// before a release is actually blocked.
+const WARN_CRATE_BYTES: u64 = MAX_CRATE_BYTES * 8 / 10;
+
+#[derive(Debug, PartialEq, Eq)]
+enum SizeStatus {
+    WithinLimit,
+    Warning,
+    Violation,
+}
+
+const fn classify_size(size_bytes: u64) -> SizeStatus {
+    if size_bytes > MAX_CRATE_BYTES {
+        SizeStatus::Violation
+    } else if size_bytes > WARN_CRATE_BYTES {
+        SizeStatus::Warning
+    } else {
+        SizeStatus::WithinLimit
+    }
+}
+
+fn format_mib(size_bytes: u64) -> String {
+    #[allow(clippy::cast_precision_loss)]
+    let mib = size_bytes as f64 / (1024.0 * 1024.0);
+    format!("{mib:.2} MiB ({size_bytes} bytes)")
+}
+
+#[cfg(not(test))]
+fn set_output(key: &str, value: &str) {
+    if let Ok(output_file) = env::var("GITHUB_OUTPUT") {
+        if let Ok(mut file) = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&output_file)
+        {
+            let _ = writeln!(file, "{key}={value}");
+        }
+    }
+    println!("Output: {key}={value}");
+}
+
+/// Locate the `.crate` archive produced by `cargo package` for the given
+/// package name and version inside `<rust_root>/target/package`.
+fn find_crate_archive(rust_root: &str, name: &str, version: &str) -> Option<PathBuf> {
+    let package_dir = if rust_root == "." {
+        PathBuf::from("target/package")
+    } else {
+        Path::new(rust_root).join("target/package")
+    };
+
+    let archive = package_dir.join(format!("{name}-{version}.crate"));
+    archive.exists().then_some(archive)
+}
+
+#[cfg(not(test))]
+fn main() {
+    let rust_root = match rust_paths::get_rust_root(None, true) {
+        Ok(root) => root,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            exit(1);
+        }
+    };
+    let cargo_toml = rust_paths::get_cargo_toml_path(&rust_root);
+    let package_manifest = match rust_paths::get_package_manifest_path(&cargo_toml) {
+        Ok(path) => path,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            exit(1);
+        }
+    };
+    let package_info = match rust_paths::read_package_info(&package_manifest) {
+        Ok(info) => info,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            exit(1);
+        }
+    };
+    let name = package_info.name;
+    let version = package_info.version;
+
+    println!("Package: {name}@{version}");
+    println!(
+        "\nBuilding `.crate` archive to verify it stays under the crates.io {} limit...\n",
+        format_mib(MAX_CRATE_BYTES)
+    );
+
+    // Generate the archive. `--no-verify` skips the recompile (the lint/test/build
+    // jobs already verify the package) while still writing the `.crate` archive,
+    // which is all this size guard needs.
+    let mut cmd = Command::new("cargo");
+    cmd.arg("package")
+        .arg("--allow-dirty")
+        .arg("--no-verify")
+        .arg("-p")
+        .arg(&name);
+    if rust_paths::needs_cd(&rust_root) {
+        cmd.current_dir(&rust_root);
+    }
+
+    let status = cmd.status().expect("Failed to execute cargo package");
+    if !status.success() {
+        eprintln!("::error::cargo package failed; cannot determine crate archive size");
+        exit(1);
+    }
+
+    let Some(archive) = find_crate_archive(&rust_root, &name, &version) else {
+        eprintln!(
+            "::error::Could not find generated archive {name}-{version}.crate in target/package"
+        );
+        exit(1);
+    };
+
+    let size_bytes = match fs::metadata(&archive) {
+        Ok(meta) => meta.len(),
+        Err(e) => {
+            eprintln!("::error::Could not read size of {}: {e}", archive.display());
+            exit(1);
+        }
+    };
+
+    set_output("crate_size_bytes", &size_bytes.to_string());
+    println!("Archive: {}", archive.display());
+    println!("Size: {}", format_mib(size_bytes));
+    println!("Limit: {}", format_mib(MAX_CRATE_BYTES));
+
+    match classify_size(size_bytes) {
+        SizeStatus::Violation => {
+            let message = format!(
+                "Packaged crate archive is {} which exceeds the crates.io upload limit of {}. \
+                 Reduce the package by adding a narrow `include` allowlist in Cargo.toml (or \
+                 `exclude` large files such as docs, case studies, generated artifacts, and \
+                 experiments). See https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields",
+                format_mib(size_bytes),
+                format_mib(MAX_CRATE_BYTES)
+            );
+            println!("::error::{message}");
+            eprintln!("\nERROR: {message}\n");
+            set_output("crate_size_check", "fail");
+            exit(1);
+        }
+        SizeStatus::Warning => {
+            let message = format!(
+                "Packaged crate archive is {} which is approaching the crates.io upload limit of {}. \
+                 Consider trimming the package with an `include`/`exclude` allowlist in Cargo.toml.",
+                format_mib(size_bytes),
+                format_mib(MAX_CRATE_BYTES)
+            );
+            println!("::warning::{message}");
+            println!("\nWARNING: {message}\n");
+            set_output("crate_size_check", "pass");
+            exit(0);
+        }
+        SizeStatus::WithinLimit => {
+            println!("\nCrate archive is within the crates.io upload limit\n");
+            set_output("crate_size_check", "pass");
+            exit(0);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn limit_matches_crates_io_documented_bytes() {
+        assert_eq!(MAX_CRATE_BYTES, 10_485_760);
+    }
+
+    #[test]
+    fn warns_before_blocking() {
+        assert_eq!(classify_size(0), SizeStatus::WithinLimit);
+        assert_eq!(classify_size(WARN_CRATE_BYTES), SizeStatus::WithinLimit);
+        assert_eq!(classify_size(WARN_CRATE_BYTES + 1), SizeStatus::Warning);
+        assert_eq!(classify_size(MAX_CRATE_BYTES), SizeStatus::Warning);
+    }
+
+    #[test]
+    fn blocks_above_hard_limit() {
+        assert_eq!(classify_size(MAX_CRATE_BYTES + 1), SizeStatus::Violation);
+        // The downstream formal-ai failure: 16.1 MiB compressed must be rejected.
+        assert_eq!(
+            classify_size(16 * 1024 * 1024 + 100 * 1024),
+            SizeStatus::Violation
+        );
+    }
+
+    #[test]
+    fn format_mib_is_human_readable() {
+        assert_eq!(format_mib(MAX_CRATE_BYTES), "10.00 MiB (10485760 bytes)");
+    }
+
+    #[test]
+    fn find_crate_archive_returns_none_when_missing() {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("check-crate-size-missing-{nanos}"));
+        fs::create_dir_all(&root).unwrap();
+        let result = find_crate_archive(root.to_str().unwrap(), "demo", "0.1.0");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn find_crate_archive_locates_generated_archive() {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("check-crate-size-found-{nanos}"));
+        let package_dir = root.join("target/package");
+        fs::create_dir_all(&package_dir).unwrap();
+        let archive = package_dir.join("demo-0.1.0.crate");
+        fs::write(&archive, b"fake archive").unwrap();
+
+        let result = find_crate_archive(root.to_str().unwrap(), "demo", "0.1.0");
+        assert_eq!(result, Some(archive));
+    }
+}

--- a/tests/unit/ci-cd/mod.rs
+++ b/tests/unit/ci-cd/mod.rs
@@ -1,4 +1,6 @@
 mod changelog_parsing;
+#[path = "../../../scripts/check-crate-size.rs"]
+mod check_crate_size;
 #[path = "../../../scripts/check-file-size.rs"]
 mod check_file_size;
 #[path = "../../../scripts/create-github-release.rs"]

--- a/tests/unit/ci-cd/workflow_release.rs
+++ b/tests/unit/ci-cd/workflow_release.rs
@@ -185,6 +185,83 @@ fn release_workflow_publishes_optional_docker_hub_image_after_crate_is_visible()
 }
 
 #[test]
+fn release_jobs_check_crate_size_before_publishing() {
+    let workflow = release_workflow();
+
+    for job_name in ["auto-release", "manual-release"] {
+        let job = job_block(&workflow, job_name);
+
+        let size_check = job
+            .find("- name: Check crate package size")
+            .unwrap_or_else(|| panic!("{job_name} should guard the crate size before publishing"));
+        let publish = job
+            .find("- name: Publish to Crates.io")
+            .unwrap_or_else(|| panic!("{job_name} should publish the crate"));
+
+        assert!(
+            size_check < publish,
+            "{job_name} should check the crate size before publishing to crates.io"
+        );
+        assert!(
+            job.contains("rust-script scripts/check-crate-size.rs"),
+            "{job_name} should run the check-crate-size guard script"
+        );
+    }
+}
+
+#[test]
+fn build_job_checks_crate_size() {
+    let workflow = release_workflow();
+    let build = job_block(&workflow, "build");
+
+    assert!(
+        build.contains("- name: Check crate package size"),
+        "build job should surface oversized packages early on PRs"
+    );
+    assert!(
+        build.contains("rust-script scripts/check-crate-size.rs"),
+        "build job should run the check-crate-size guard script"
+    );
+}
+
+#[test]
+fn crate_size_guard_uses_documented_crates_io_limit() {
+    let script = fs::read_to_string(format!(
+        "{}/scripts/check-crate-size.rs",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .unwrap();
+
+    assert!(
+        script.contains("10 * 1024 * 1024"),
+        "size guard should encode the crates.io 10 MiB upload limit"
+    );
+}
+
+#[test]
+fn cargo_manifest_uses_narrow_include_allowlist() {
+    let manifest =
+        fs::read_to_string(format!("{}/Cargo.toml", env!("CARGO_MANIFEST_DIR"))).unwrap();
+
+    assert!(
+        manifest.contains("include = ["),
+        "Cargo.toml should declare a narrow include allowlist to keep release archives small"
+    );
+    assert!(
+        manifest.contains("\"src/**/*.rs\""),
+        "include allowlist should ship the crate sources"
+    );
+    // Docs, case studies, changelog fragments, scripts, and experiments must not
+    // be opted into the published archive.
+    for excluded in ["\"docs/", "\"changelog.d/", "\"scripts/", "\"experiments/"] {
+        assert!(
+            !manifest.contains(excluded),
+            "include allowlist should not bundle {excluded} into release archives"
+        );
+    }
+}
+
+#[test]
 fn release_scripts_check_configured_release_artifacts() {
     let release_check = fs::read_to_string(format!(
         "{}/scripts/check-release-needed.rs",


### PR DESCRIPTION
## Summary

Adds a preventive **crates.io package size guard** to the Rust template so a release is never silently published past the crates.io 10 MiB (`10485760` bytes) upload limit.

Fixes #58.

Motivated by a downstream failure where `cargo publish` packaged 792 files / 16.1 MiB compressed and crates.io rejected the upload with HTTP 413 (link-assistant/formal-ai#121). The root cause was that the template release workflow ran `cargo package --list` but never failed on an oversized archive, and `Cargo.toml` had no `include` allowlist.

## What changed

1. **`scripts/check-crate-size.rs`** — builds the `.crate` archive (`cargo package --allow-dirty --no-verify`), measures it, and fails with a clear, actionable error when it exceeds the documented 10 MiB crates.io limit. Emits a non-blocking warning at 80% of the limit. Supports single- and multi-language repo layouts via the shared `rust-paths` helper.
2. **Workflow wiring** (`.github/workflows/release.yml`):
   - Runs the guard in the `build` job (early PR feedback) after `cargo package --list`.
   - Runs the guard **before** `Publish to Crates.io` in both the `auto-release` and `manual-release` jobs.
3. **Narrow `include` allowlist in `Cargo.toml`** — ships only `src/**/*.rs`, `examples/**/*.rs`, `README.md`, `LICENSE`, and `CHANGELOG.md`, so docs, case studies, generated CI artifacts, changelog fragments, scripts, and experiments no longer inflate the archive. Compressed archive dropped from ~697 KiB to ~41 KiB.
4. **Tests**:
   - Unit tests for `classify_size` (within-limit / warning / violation, incl. the 16.1 MiB downstream value), the documented byte limit, `format_mib`, and `find_crate_archive`.
   - Workflow tests asserting the size check runs **before** publish in both release jobs, runs in the build job, encodes the 10 MiB limit, and that `Cargo.toml` uses a narrow `include` allowlist that excludes `docs/`, `changelog.d/`, `scripts/`, and `experiments/`.
5. **Docs** — new "Crate Package Too Large (HTTP 413)" troubleshooting section, plus README script references.

## How to reproduce / verify

Before the fix, `cargo package --list` bundled `docs/case-studies/**`, `changelog.d/**`, `scripts/**`, etc. with no size enforcement. Now:

```bash
rust-script scripts/check-crate-size.rs
# Builds the archive, prints size vs the 10 MiB limit, exits non-zero if exceeded.
```

## Local checks

```
cargo fmt --all -- --check        # clean
cargo clippy --all-targets --all-features   # clean (-Dwarnings)
cargo test --all-features         # 46 passed
rust-script scripts/check-crate-size.rs     # 0.04 MiB — within limit
```
