### PR TITLE
fix: classify GitHub release validation errors

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-12T22:59:34.075Z for PR creation at branch issue-50-f6272907aac6 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/50
+# Updated: 2026-06-04T17:15:00.951Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-05-12T22:59:34.075Z for PR creation at branch issue-50-f6272907aac6 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/50
-# Updated: 2026-06-04T17:15:00.951Z

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,7 @@ dependencies = [
  "clap",
  "lino-arguments",
  "regex",
+ "serde_json",
  "walkdir",
 ]
 
@@ -165,6 +166,12 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lino-arguments"
@@ -285,6 +292,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,3 +386,9 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ clap = { version = "4.4", features = ["derive", "env"] }
 
 [dev-dependencies]
 regex = "1"
+serde_json = "1"
 walkdir = "2"
 
 [lints.rust]

--- a/changelog.d/20260604_172100_github_release_validation.md
+++ b/changelog.d/20260604_172100_github_release_validation.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Prevented GitHub release creation from treating generic API validation failures as existing releases, and capped oversized release notes with a link to the full tagged changelog.

--- a/scripts/create-github-release.rs
+++ b/scripts/create-github-release.rs
@@ -30,6 +30,8 @@ use std::process::{exit, Command, Stdio};
 #[cfg(not(test))]
 const USAGE: &str = "Usage: rust-script scripts/create-github-release.rs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <name>] [--release-label <label>] [--docker-hub-url <url>]";
 
+const GITHUB_RELEASE_BODY_MAX_CHARS: usize = 125_000;
+
 #[cfg(not(test))]
 fn get_rust_root() -> String {
     if let Some(root) = get_arg("rust-root") {
@@ -53,6 +55,15 @@ fn get_cargo_toml_path(rust_root: &str) -> String {
         "./Cargo.toml".to_string()
     } else {
         format!("{rust_root}/Cargo.toml")
+    }
+}
+
+#[cfg(not(test))]
+fn get_changelog_path(rust_root: &str) -> String {
+    if rust_root == "." {
+        "./CHANGELOG.md".to_string()
+    } else {
+        format!("{rust_root}/CHANGELOG.md")
     }
 }
 
@@ -163,9 +174,7 @@ fn docker_hub_badge(url: &str, version: &str) -> String {
 }
 
 #[cfg(not(test))]
-fn get_changelog_for_version(version: &str) -> String {
-    let changelog_path = "CHANGELOG.md";
-
+fn get_changelog_for_version(changelog_path: &str, version: &str) -> String {
     if !Path::new(changelog_path).exists() {
         return format!("Release v{version}");
     }
@@ -226,6 +235,79 @@ fn build_release_payload(
     }
 }
 
+fn is_existing_release_error(combined: &str) -> bool {
+    let Some(error) = parse_first_json_object(combined) else {
+        return false;
+    };
+    let Some(errors) = error.get("errors").and_then(serde_json::Value::as_array) else {
+        return false;
+    };
+
+    !errors.is_empty()
+        && errors.iter().all(|error| {
+            error.get("resource").and_then(serde_json::Value::as_str) == Some("Release")
+                && error.get("code").and_then(serde_json::Value::as_str) == Some("already_exists")
+                && error.get("field").and_then(serde_json::Value::as_str) == Some("tag_name")
+        })
+}
+
+fn parse_first_json_object(output: &str) -> Option<serde_json::Value> {
+    output.match_indices('{').find_map(|(start, _)| {
+        let mut values =
+            serde_json::Deserializer::from_str(&output[start..]).into_iter::<serde_json::Value>();
+        let value = values.next()?.ok()?;
+
+        matches!(value, serde_json::Value::Object(_)).then_some(value)
+    })
+}
+
+fn normalize_changelog_blob_path(changelog_path: &str) -> String {
+    changelog_path
+        .replace('\\', "/")
+        .trim_start_matches("./")
+        .trim_start_matches('/')
+        .to_string()
+}
+
+fn full_changelog_url(repository: &str, tag: &str, changelog_path: &str) -> String {
+    format!(
+        "https://github.com/{repository}/blob/{tag}/{}",
+        normalize_changelog_blob_path(changelog_path)
+    )
+}
+
+fn cap_release_notes(
+    release_notes: String,
+    repository: &str,
+    tag: &str,
+    changelog_path: &str,
+) -> String {
+    if release_notes.chars().count() <= GITHUB_RELEASE_BODY_MAX_CHARS {
+        return release_notes;
+    }
+
+    let footer = format!(
+        "\n\nRelease notes truncated. See the [full changelog]({}).",
+        full_changelog_url(repository, tag, changelog_path)
+    );
+    let marker = "\n\n...";
+    let reserved_chars = footer.chars().count() + marker.chars().count();
+
+    if reserved_chars >= GITHUB_RELEASE_BODY_MAX_CHARS {
+        return release_notes
+            .chars()
+            .take(GITHUB_RELEASE_BODY_MAX_CHARS)
+            .collect();
+    }
+
+    let keep_chars = GITHUB_RELEASE_BODY_MAX_CHARS - reserved_chars;
+    let mut truncated = release_notes.chars().take(keep_chars).collect::<String>();
+    let trimmed_len = truncated.trim_end().len();
+    truncated.truncate(trimmed_len);
+
+    format!("{truncated}{marker}{footer}")
+}
+
 #[cfg(not(test))]
 fn main() {
     let version = match get_arg("release-version") {
@@ -266,7 +348,8 @@ fn main() {
         }
     }
 
-    let mut release_notes = get_changelog_for_version(&normalized_version);
+    let changelog_path = get_changelog_path(&rust_root);
+    let mut release_notes = get_changelog_for_version(&changelog_path, &normalized_version);
     let mut badges = Vec::new();
     if let Some(crate_name) = get_crate_name_from_toml(&cargo_toml) {
         let crate_badges = format!(
@@ -284,6 +367,9 @@ fn main() {
     if let Some(url) = crates_io_url {
         release_notes = format!("{url}\n\n{release_notes}");
     }
+
+    let release_tag = build_release_tag(&tag_prefix, &normalized_version);
+    release_notes = cap_release_notes(release_notes, &repository, &release_tag, &changelog_path);
 
     let payload = build_release_payload(
         &tag_prefix,
@@ -328,13 +414,15 @@ fn main() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let combined = format!("{stderr}{stdout}");
-        if combined.contains("already exists")
-            || combined.contains("already_exists")
-            || combined.contains("Validation Failed")
-        {
+        if is_existing_release_error(&combined) {
             println!("Release {tag} already exists, skipping");
         } else {
-            eprintln!("Error creating release: {stderr}");
+            let details = combined.trim();
+            if details.is_empty() {
+                eprintln!("Error creating release: gh api exited unsuccessfully");
+            } else {
+                eprintln!("Error creating release:\n{details}");
+            }
             exit(1);
         }
     }
@@ -409,5 +497,39 @@ mod tests {
 
         assert!(badge.contains("1.2.3%2Bbuild.4"));
         assert!(badge.contains("tags?name=1.2.3%2Bbuild.4"));
+    }
+
+    #[test]
+    fn duplicate_release_validation_is_idempotent() {
+        let output = r#"gh: Validation Failed (HTTP 422)
+{"message":"Validation Failed","errors":[{"resource":"Release","code":"already_exists","field":"tag_name"}]}"#;
+
+        assert!(is_existing_release_error(output));
+    }
+
+    #[test]
+    fn generic_validation_failure_is_not_existing_release() {
+        let output = r#"gh: Validation Failed (HTTP 422)
+{"message":"Validation Failed","errors":[{"resource":"Release","code":"custom","field":"body"}]}"#;
+
+        assert!(!is_existing_release_error(output));
+    }
+
+    #[test]
+    fn mixed_validation_failure_is_not_existing_release() {
+        let output = r#"gh: Validation Failed (HTTP 422)
+{"message":"Validation Failed","errors":[{"resource":"Release","code":"already_exists","field":"tag_name"},{"resource":"Release","code":"custom","field":"body"}]}"#;
+
+        assert!(!is_existing_release_error(output));
+    }
+
+    #[test]
+    fn oversized_release_notes_are_capped_with_full_changelog_link() {
+        let release_notes = "a".repeat(GITHUB_RELEASE_BODY_MAX_CHARS + 100);
+        let capped = cap_release_notes(release_notes, "owner/repo", "v1.2.3", "./CHANGELOG.md");
+
+        assert!(capped.chars().count() <= GITHUB_RELEASE_BODY_MAX_CHARS);
+        assert!(capped.contains("Release notes truncated"));
+        assert!(capped.contains("https://github.com/owner/repo/blob/v1.2.3/CHANGELOG.md"));
     }
 }


### PR DESCRIPTION
Fixes #63

## Summary
- Parse `gh api` validation response JSON and only treat a release as already existing when every validation error is `resource=Release`, `code=already_exists`, and `field=tag_name`.
- Fail generic GitHub API validation errors instead of printing a false successful skip.
- Cap generated GitHub release notes at 125,000 characters and append a link to the full tagged `CHANGELOG.md` when truncation is needed.
- Add regression tests for duplicate-release detection, generic validation failures, mixed validation failures, and oversized release notes.

## Root Cause
`create-github-release.rs` matched the broad text `Validation Failed`, so unrelated HTTP 422 responses from GitHub were classified as an existing release. That let cases like an oversized release body look successful even though no GitHub release was created.

## Reproduction
1. Make `gh api repos/OWNER/REPO/releases -X POST` return `gh: Validation Failed (HTTP 422)` with an error other than `Release/already_exists/tag_name`, such as a body validation failure.
2. Run `rust-script scripts/create-github-release.rs --release-version 1.2.3 --repository OWNER/REPO`.
3. Before this fix, the script printed `Release v1.2.3 already exists, skipping`; after this fix, it exits non-zero and prints the real `gh api` error details.

## Tests
- [x] Confirmed new regression tests failed before implementation: `cargo test --test unit create_github_release -- --nocapture`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all-features --verbose`
- [x] `cargo test --doc --verbose`
- [x] `cargo clippy --all-targets --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build --release --verbose`
- [x] `cargo package --list --allow-dirty`
- [x] `rust-script scripts/check-file-size.rs`
- [x] `GITHUB_BASE_REF=main rust-script scripts/check-changelog-fragment.rs`
- [x] `rust-script scripts/create-github-release.rs --release-version 0.16.0 --repository owner/repo` (compiles and exits through the template-package skip path)
