### PR TITLE
fix: resilient buildx boot with retry + mirror fallback (#69)

### DIFF
--- a/.github/actions/setup-buildx-resilient/action.yml
+++ b/.github/actions/setup-buildx-resilient/action.yml
@@ -1,0 +1,110 @@
+name: 'Set up Docker Buildx (resilient)'
+description: >
+  Wrapper around docker/setup-buildx-action that first pre-pulls the pinned
+  BuildKit image with retries and exponential backoff, and — when Docker Hub
+  itself is unreachable — falls back to a pull-through registry mirror
+  (mirror.gcr.io by default) before re-tagging the image to its canonical
+  reference. Booting the docker-container driver otherwise pulls moby/buildkit
+  straight from Docker Hub, and a transient registry timeout there fails the
+  whole publish job even when nothing is wrong with the code or the build.
+  Seeding the image locally first means the boot reuses the cached image
+  instead of hitting the registry, and the mirror fallback keeps the seed
+  working even during a full Docker Hub registry outage.
+  See docs/case-studies/issue-69/README.md and the upstream investigations in
+  link-foundation/box issues #97 and #100.
+inputs:
+  buildkit-image:
+    description: 'Pinned BuildKit image used by the docker-container driver.'
+    required: false
+    default: 'moby/buildkit:buildx-stable-1'
+  registry-mirror:
+    description: >
+      Pull-through Docker Hub mirror host used as a fallback when the canonical
+      registry (registry-1.docker.io) is unreachable. mirror.gcr.io is Google's
+      public pull-through cache of Docker Hub and is served from independent
+      infrastructure, so it typically stays reachable during Docker Hub
+      registry outages. Set to an empty string to disable the mirror fallback.
+    required: false
+    default: 'mirror.gcr.io'
+  verbose:
+    description: >
+      Set to "true" to enable shell tracing (set -x) in the pre-pull step for
+      debugging. Tracing is also enabled automatically when the workflow is run
+      with step debug logging (RUNNER_DEBUG=1).
+    required: false
+    default: 'false'
+runs:
+  using: 'composite'
+  steps:
+    - name: Pre-pull BuildKit image (retry + registry-mirror fallback)
+      shell: bash
+      env:
+        BUILDKIT_IMAGE: ${{ inputs.buildkit-image }}
+        REGISTRY_MIRROR: ${{ inputs.registry-mirror }}
+        VERBOSE: ${{ inputs.verbose }}
+      run: |
+        set -u
+        # Verbose/debug tracing: opt-in via input, or automatic when the run is
+        # started with "Enable debug logging" (RUNNER_DEBUG=1). Kept off by
+        # default so normal logs stay readable.
+        if [ "${VERBOSE}" = "true" ] || [ "${RUNNER_DEBUG:-}" = "1" ]; then
+          echo "==> Verbose tracing enabled"
+          set -x
+        fi
+
+        # Pull a reference with bounded retries and exponential backoff.
+        # Returns 0 on the first successful pull, non-zero if all attempts fail.
+        pull_with_retries() {
+          ref="$1"
+          # Attempts/backoff are overridable via env so the unit test can run
+          # fast; the CI defaults stay at 5 attempts / 5s exponential backoff.
+          attempts="${PREPULL_ATTEMPTS:-5}"
+          delay="${PREPULL_DELAY:-5}"
+          for attempt in $(seq 1 "$attempts"); do
+            echo "==> Pulling ${ref} (attempt ${attempt}/${attempts})..."
+            if docker pull "${ref}"; then
+              return 0
+            fi
+            if [ "$attempt" -lt "$attempts" ]; then
+              echo "==> Pull failed, waiting ${delay}s before next attempt..."
+              sleep "$delay"
+              delay=$((delay * 2))
+            fi
+          done
+          return 1
+        }
+
+        # 1) Canonical Docker Hub. The common transient-blip case recovers here.
+        if pull_with_retries "${BUILDKIT_IMAGE}"; then
+          echo "==> BuildKit image cached locally from canonical registry; boot will not need a registry pull"
+          exit 0
+        fi
+
+        # 2) Registry-mirror fallback. When Docker Hub's registry endpoint is
+        #    fully unreachable (issue #69: registry-1.docker.io timed out for
+        #    longer than a normal blip), the canonical pull above cannot recover
+        #    no matter how many times it retries. mirror.gcr.io is a
+        #    pull-through cache of Docker Hub on independent infrastructure, so
+        #    it usually still serves the image. We pull from there and re-tag to
+        #    the canonical reference so the docker-container driver boot finds it
+        #    locally and never touches the failing registry.
+        if [ -n "${REGISTRY_MIRROR}" ]; then
+          mirror_ref="${REGISTRY_MIRROR}/${BUILDKIT_IMAGE}"
+          echo "==> Canonical pull failed; trying registry mirror ${mirror_ref}"
+          if pull_with_retries "${mirror_ref}"; then
+            docker tag "${mirror_ref}" "${BUILDKIT_IMAGE}"
+            echo "==> BuildKit image cached locally via mirror and tagged as ${BUILDKIT_IMAGE}; boot will reuse it"
+            exit 0
+          fi
+          echo "==> Mirror pull from ${REGISTRY_MIRROR} also failed"
+        fi
+
+        # Non-fatal: fall through to setup-buildx, which will attempt its own
+        # pull during boot. This preserves the previous behaviour in the worst
+        # case while making the common transient-failure case recover.
+        echo "==> WARNING: could not pre-pull ${BUILDKIT_IMAGE} from canonical registry or mirror; letting setup-buildx try its own boot pull"
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+      with:
+        driver-opts: image=${{ inputs.buildkit-image }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,9 +410,13 @@ jobs:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_TOKEN }}
 
+      # Resilient buildx boot: pre-pull the pinned BuildKit image with retries
+      # and a pull-through registry-mirror fallback so a transient Docker Hub
+      # outage at boot does not take the publish job down. See issue #69 and
+      # docs/case-studies/issue-69/README.md.
       - name: Set up Docker Buildx
         if: steps.dockerhub.outputs.enabled == 'true'
-        uses: docker/setup-buildx-action@v4
+        uses: ./.github/actions/setup-buildx-resilient
 
       - name: Extract Docker metadata
         if: steps.dockerhub.outputs.enabled == 'true'
@@ -565,9 +569,13 @@ jobs:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_TOKEN }}
 
+      # Resilient buildx boot: pre-pull the pinned BuildKit image with retries
+      # and a pull-through registry-mirror fallback so a transient Docker Hub
+      # outage at boot does not take the publish job down. See issue #69 and
+      # docs/case-studies/issue-69/README.md.
       - name: Set up Docker Buildx
         if: steps.dockerhub.outputs.enabled == 'true'
-        uses: docker/setup-buildx-action@v4
+        uses: ./.github/actions/setup-buildx-resilient
 
       - name: Extract Docker metadata
         if: steps.dockerhub.outputs.enabled == 'true'

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-12T22:59:34.075Z for PR creation at branch issue-50-f6272907aac6 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/50
 # Updated: 2026-06-08T14:37:24.907Z
 # Updated: 2026-06-09T18:09:35.976Z
+# Updated: 2026-06-13T08:50:05.927Z

--- a/changelog.d/20260613_085500_buildx-resilient-boot.md
+++ b/changelog.d/20260613_085500_buildx-resilient-boot.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Harden the Docker publish step against transient Docker Hub registry outages. `release.yml` now boots buildx via the new `setup-buildx-resilient` composite action, which pre-pulls the pinned `moby/buildkit:buildx-stable-1` image with retries and a `mirror.gcr.io` pull-through fallback before the docker-container driver boots, so a registry blip no longer fails the release ([#69](https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/69)).

--- a/docs/case-studies/issue-69/README.md
+++ b/docs/case-studies/issue-69/README.md
@@ -1,0 +1,101 @@
+# Case Study: Issue #69 — Transient Docker Hub outage fails the buildx boot and takes the publish job down
+
+## Summary
+
+Issue [#69](https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/69)
+reports that `release.yml` booted buildx with `docker/setup-buildx-action@v4`
+and **no pinned-image pre-pull**. The default `docker-container` driver makes
+`dockerd` pull `moby/buildkit:buildx-stable-1` from Docker Hub at boot. When
+`registry-1.docker.io` has a transient outage, that boot pull fails and takes
+the whole publish job down — even though nothing is wrong with the code or the
+build.
+
+The failure surfaces at **Set up Docker Buildx → Creating a new builder
+instance** with:
+
+```
+ERROR: Error response from daemon: Get "https://registry-1.docker.io/v2/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
+```
+
+This is the same class of failure investigated downstream in
+[`link-foundation/box#100`](https://github.com/link-foundation/box/issues/100)
+(a ~2.5-minute Docker Hub registry outage failed the buildx boot) and
+originally [`link-foundation/box#97`](https://github.com/link-foundation/box/issues/97).
+
+## Root cause
+
+The `docker-container` buildx driver runs BuildKit inside a container. To start
+it, `dockerd` must have the `moby/buildkit:buildx-stable-1` image locally; if it
+does not, it pulls it from Docker Hub **at boot time**. There was no local copy
+seeded before the boot and no retry/fallback around that pull, so any blip on
+`registry-1.docker.io` that outlasts a single attempt fails the boot and, with
+it, the entire `auto-release` / `manual-release` Docker publish step. The build
+itself never even starts.
+
+This is a pure infrastructure-availability failure: a transient third-party
+registry outage is misreported as a release failure.
+
+## Fix
+
+Pre-pull the pinned BuildKit image **before** booting, with:
+
+1. **Bounded retries with exponential backoff** against the canonical Docker Hub
+   reference. This absorbs the common short blip.
+2. **A pull-through registry-mirror fallback** (`mirror.gcr.io`, Google's public
+   pull-through cache of Docker Hub, on independent infrastructure). When Docker
+   Hub's registry endpoint is fully unreachable, retrying the canonical
+   reference cannot recover no matter how many attempts — the mirror usually
+   still serves the image.
+3. **A re-tag to the canonical reference.** After a successful mirror pull, the
+   image is `docker tag`-ed back to `moby/buildkit:buildx-stable-1` so the
+   docker-container driver boot finds it locally and never touches the failing
+   registry.
+4. **Non-fatal fall-through.** If both the canonical registry and the mirror are
+   down, the step emits a warning and lets `docker/setup-buildx-action` attempt
+   its own boot pull — preserving the previous worst-case behaviour while making
+   the common transient-failure case recover.
+5. **A pinned boot driver image.** `driver-opts: image=moby/buildkit:buildx-stable-1`
+   ensures the boot reuses exactly the reference that was seeded locally.
+
+The logic is packaged as a reusable composite action,
+[`.github/actions/setup-buildx-resilient`](../../../.github/actions/setup-buildx-resilient/action.yml),
+ported from `link-foundation/box`'s `setup-buildx-resilient`. Both the
+`auto-release` and `manual-release` jobs in `release.yml` now use it in place of
+the bare `docker/setup-buildx-action@v4` step:
+
+```yaml
+- name: Set up Docker Buildx
+  if: steps.dockerhub.outputs.enabled == 'true'
+  uses: ./.github/actions/setup-buildx-resilient
+```
+
+Because it is a local composite action, the job's existing `actions/checkout`
+step must run first (both jobs already check out at the top).
+
+## Verification
+
+`experiments/test-issue69-buildx-mirror-fallback.sh` extracts the real pre-pull
+script from `action.yml` and drives it with a mock `docker` that can
+independently fail the canonical registry and/or the mirror. It asserts:
+
+| Scenario | Expected behaviour |
+| --- | --- |
+| Canonical Docker Hub healthy | Pulls canonical image, never touches the mirror, no re-tag, exits 0 |
+| Docker Hub down, mirror healthy (the issue #69 scenario) | Pulls from `mirror.gcr.io`, re-tags to the canonical ref, exits 0 |
+| Both canonical and mirror down | Attempts the mirror, warns, exits 0 (non-fatal fall-through) |
+
+Plus static checks that `action.yml` declares the `registry-mirror` input,
+defaults it to `mirror.gcr.io`, supports verbose tracing / `RUNNER_DEBUG`, and
+pins the boot driver image.
+
+Run it locally with:
+
+```bash
+bash experiments/test-issue69-buildx-mirror-fallback.sh
+```
+
+## References
+
+- Upstream resilient action: [`link-foundation/box` `setup-buildx-resilient`](https://github.com/link-foundation/box/blob/main/.github/actions/setup-buildx-resilient/action.yml)
+- Upstream case study: [`link-foundation/box` issue #100 CASE-STUDY](https://github.com/link-foundation/box/blob/main/docs/case-studies/issue-100/CASE-STUDY.md)
+- `mirror.gcr.io` (Google Cloud's pull-through Docker Hub mirror)

--- a/experiments/test-issue69-buildx-mirror-fallback.sh
+++ b/experiments/test-issue69-buildx-mirror-fallback.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Unit test / reproduction for the issue #69 buildx-boot resilience hardening in
+# .github/actions/setup-buildx-resilient/action.yml.
+#
+# Root cause (issue #69): release.yml booted buildx with
+# docker/setup-buildx-action and no pinned-image pre-pull. The default
+# docker-container driver makes dockerd pull moby/buildkit:buildx-stable-1 from
+# Docker Hub at boot. When registry-1.docker.io has a transient outage, that
+# boot pull fails and takes the whole publish job down even though nothing is
+# wrong with the code or the build.
+#
+# The fix pre-pulls the pinned BuildKit image with retries and adds a
+# pull-through registry-mirror fallback (mirror.gcr.io) plus a re-tag to the
+# canonical reference, so a full Docker Hub outage no longer fails the boot.
+# This test extracts the real pre-pull script out of action.yml and drives it
+# with a mock `docker` that can independently fail the canonical registry
+# and/or the mirror, asserting the recovery behaviour for every case.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ACTION="$SCRIPT_DIR/../.github/actions/setup-buildx-resilient/action.yml"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- Extract the pre-pull step's `run: |` block verbatim from the action ---
+# The block starts after the first "run: |" and ends at the next less-indented
+# YAML key ("    - name:"). We dedent by the script's own indentation.
+ruby >"$WORK/prepull.sh" <<RUBY
+text = File.read("$ACTION", encoding: "UTF-8")
+lines = text.lines
+start = lines.index { |l| l =~ /^\s*run: \|\s*$/ }
+raise "could not find 'run: |' in action.yml" unless start
+body = []
+indent = nil
+lines[(start + 1)..].each do |line|
+  # Stop at the next step (a "- name:" at 4-space indent) or any key at <=4 indent.
+  break if line =~ /^\s{0,4}- name:/
+  if line.strip.empty?
+    body << "\n"
+    next
+  end
+  indent ||= line[/^\s*/].length
+  body << line[indent..]
+end
+print body.join
+RUBY
+
+if [ ! -s "$WORK/prepull.sh" ]; then
+  echo "FAIL: could not extract pre-pull script from action.yml"
+  exit 1
+fi
+
+# --- Mock docker on PATH; records calls, fails canonical/mirror per fixture ---
+mkdir -p "$WORK/bin"
+cat >"$WORK/bin/docker" <<'MOCK'
+#!/usr/bin/env bash
+# Fixtures (env): CANONICAL_OK / MIRROR_OK = 1 means that source serves pulls.
+echo "$*" >> "$DOCKER_CALLS"
+case "$1" in
+  pull)
+    ref="$2"
+    case "$ref" in
+      mirror.gcr.io/*)
+        [ "${MIRROR_OK:-0}" = "1" ] && { echo "$ref" >> "$DOCKER_PULLED"; exit 0; }
+        echo 'Error response from daemon: Get "https://mirror.gcr.io/v2/": timeout' >&2
+        exit 1 ;;
+      *)
+        [ "${CANONICAL_OK:-0}" = "1" ] && { echo "$ref" >> "$DOCKER_PULLED"; exit 0; }
+        echo 'Error response from daemon: Get "https://registry-1.docker.io/v2/": timeout' >&2
+        exit 1 ;;
+    esac ;;
+  tag)
+    echo "tag $2 $3" >> "$DOCKER_TAGGED"; exit 0 ;;
+  *) exit 0 ;;
+esac
+MOCK
+chmod +x "$WORK/bin/docker"
+
+PASS=0
+FAIL=0
+check() { # check <desc> <condition-cmd...>
+  local desc="$1"; shift
+  if "$@"; then echo "  ok: $desc"; PASS=$((PASS + 1)); else echo "  FAIL: $desc"; FAIL=$((FAIL + 1)); fi
+}
+
+run_case() { # run_case <name> <canonical_ok> <mirror_ok>
+  local name="$1" canonical="$2" mirror="$3"
+  export DOCKER_CALLS="$WORK/calls.$name"
+  export DOCKER_PULLED="$WORK/pulled.$name"
+  export DOCKER_TAGGED="$WORK/tagged.$name"
+  : >"$DOCKER_CALLS"; : >"$DOCKER_PULLED"; : >"$DOCKER_TAGGED"
+  set +e
+  PATH="$WORK/bin:$PATH" \
+    BUILDKIT_IMAGE="moby/buildkit:buildx-stable-1" \
+    REGISTRY_MIRROR="mirror.gcr.io" \
+    VERBOSE="false" \
+    PREPULL_ATTEMPTS="2" PREPULL_DELAY="1" \
+    CANONICAL_OK="$canonical" MIRROR_OK="$mirror" \
+    bash "$WORK/prepull.sh" >"$WORK/out.$name" 2>&1
+  echo $? >"$WORK/rc.$name"
+  set -e
+}
+
+echo "== Case 1: canonical Docker Hub healthy =="
+run_case canon 1 0
+check "exits 0" test "$(cat "$WORK/rc.canon")" = "0"
+check "pulled canonical image" grep -qx "moby/buildkit:buildx-stable-1" "$WORK/pulled.canon"
+check "did NOT touch the mirror" bash -c '! grep -q mirror.gcr.io "$1"' _ "$WORK/calls.canon"
+check "did NOT need to tag" test ! -s "$WORK/tagged.canon"
+
+echo "== Case 2: Docker Hub down, mirror healthy (issue #69 scenario) =="
+run_case mirror 0 1
+check "exits 0 (recovered via mirror)" test "$(cat "$WORK/rc.mirror")" = "0"
+check "pulled from mirror" grep -qx "mirror.gcr.io/moby/buildkit:buildx-stable-1" "$WORK/pulled.mirror"
+check "re-tagged mirror image to canonical ref" grep -qx \
+  "tag mirror.gcr.io/moby/buildkit:buildx-stable-1 moby/buildkit:buildx-stable-1" "$WORK/tagged.mirror"
+
+echo "== Case 3: both canonical and mirror down =="
+run_case both 0 0
+# Non-fatal by design: the step must still exit 0 so buildx boot can try itself.
+check "exits 0 (non-fatal fall-through)" test "$(cat "$WORK/rc.both")" = "0"
+check "attempted the mirror before giving up" grep -q mirror.gcr.io "$WORK/calls.both"
+check "warned about full failure" grep -q "could not pre-pull" "$WORK/out.both"
+
+echo "== Static checks on action.yml =="
+check "declares registry-mirror input" grep -q "registry-mirror:" "$ACTION"
+check "defaults mirror to mirror.gcr.io" grep -q "default: 'mirror.gcr.io'" "$ACTION"
+check "supports verbose tracing" grep -q "set -x" "$ACTION"
+check "honours RUNNER_DEBUG" grep -q "RUNNER_DEBUG" "$ACTION"
+check "pins boot driver image" grep -q "driver-opts: image=" "$ACTION"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "All issue #69 buildx mirror-fallback checks passed."


### PR DESCRIPTION
## Summary

Fixes #69.

`release.yml` booted buildx with `docker/setup-buildx-action@v4` and no pinned-image pre-pull. The default `docker-container` driver makes `dockerd` pull `moby/buildkit:buildx-stable-1` from Docker Hub **at boot**, so a transient `registry-1.docker.io` outage failed the boot and took the whole publish job down — even when nothing was wrong with the code or the build:

```
ERROR: Error response from daemon: Get "https://registry-1.docker.io/v2/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```

## What changed

- **New composite action** `.github/actions/setup-buildx-resilient` (ported from `link-foundation/box`'s `setup-buildx-resilient`). It pre-pulls the pinned BuildKit image before boot with:
  - bounded retries + exponential backoff against canonical Docker Hub (absorbs the common blip);
  - a **`mirror.gcr.io` pull-through fallback** on independent infrastructure (survives a full Docker Hub registry outage), then a re-tag to the canonical reference so the boot reuses the local copy and never touches the failing registry;
  - non-fatal fall-through (warns and lets `setup-buildx-action` try its own boot pull if both sources are down — preserves prior worst-case behaviour);
  - a pinned boot driver image (`driver-opts: image=moby/buildkit:buildx-stable-1`).
- **`release.yml`**: both the `auto-release` and `manual-release` Docker Buildx steps now use the resilient action instead of the bare `docker/setup-buildx-action@v4`.
- **Case study**: `docs/case-studies/issue-69/README.md`.
- **Changelog fragment** (`bump: patch`).

## Reproduction & test

`experiments/test-issue69-buildx-mirror-fallback.sh` extracts the real pre-pull script from `action.yml` and drives it with a mock `docker` that can independently fail the canonical registry and/or the mirror:

| Scenario | Expected | Result |
| --- | --- | --- |
| Canonical Docker Hub healthy | pull canonical, no mirror, no re-tag, exit 0 | ✅ |
| Docker Hub down, mirror healthy (the #69 scenario) | pull from mirror, re-tag to canonical, exit 0 | ✅ |
| Both down | attempt mirror, warn, exit 0 (non-fatal) | ✅ |

Plus static checks on the action (`registry-mirror` input + default, verbose/`RUNNER_DEBUG` tracing, pinned boot driver image).

```
$ bash experiments/test-issue69-buildx-mirror-fallback.sh
PASS=15 FAIL=0
All issue #69 buildx mirror-fallback checks passed.
```
