### PR TITLE
fix: add docs pages root redirect

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -767,13 +767,28 @@ jobs:
       - name: Build documentation
         run: cargo doc --no-deps --all-features
 
+      - name: Generate Pages root index
+        run: |
+          # rustdoc emits target/doc/<crate>/index.html but no root index.html,
+          # which makes the GitHub Pages root URL return 404. Redirect the root
+          # to the crate docs directory that rustdoc generated.
+          crate=$(cargo metadata --no-deps --format-version 1 \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["name"].replace("-","_"))')
+          printf '<!doctype html><meta http-equiv="refresh" content="0; url=%s/index.html">\n' "$crate" \
+            > target/doc/index.html
+          touch target/doc/.nojekyll
+
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v6
+
+      - name: Verify site tree
+        run: find target/doc -maxdepth 2 -print
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:
           path: target/doc
+          include-hidden-files: true
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-14T12:55:51.214Z for PR creation at branch issue-79-b0b3c30857fa for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/79

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-14T12:55:51.214Z for PR creation at branch issue-79-b0b3c30857fa for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/79

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Add a visible Docker Hub badge next to the crates.io badge in repositories that 
 
 ## Deploying API documentation
 
-The `deploy-docs` job in `.github/workflows/release.yml` publishes `cargo doc --no-deps --all-features` output to GitHub Pages on every push to `main` and on `workflow_dispatch` with `release_mode == 'instant'`. It uses the official `actions/configure-pages` / `actions/upload-pages-artifact` / `actions/deploy-pages` flow, which requires the repository's Pages source to be set to **GitHub Actions**.
+The `deploy-docs` job in `.github/workflows/release.yml` publishes `cargo doc --no-deps --all-features` output to GitHub Pages on every push to `main` and on `workflow_dispatch` with `release_mode == 'instant'`. It adds a root `index.html` redirect to the generated crate documentation and a `.nojekyll` marker so rustdoc assets are served verbatim. It uses the official `actions/configure-pages` / `actions/upload-pages-artifact` / `actions/deploy-pages` flow, which requires the repository's Pages source to be set to **GitHub Actions**.
 
 Before the first run on `main`, open **Settings → Pages** of the new repository and set **Source = GitHub Actions**. This is a one-time manual step and cannot be configured from a workflow. The `deploy-docs` job will then provision the Pages site on its first run.
 

--- a/changelog.d/20260614_125806_docs_pages_root.md
+++ b/changelog.d/20260614_125806_docs_pages_root.md
@@ -1,0 +1,2 @@
+### Fixed
+- Generate a GitHub Pages root redirect for deployed rustdoc output so the documentation site root no longer 404s.

--- a/tests/unit/ci-cd/workflow_release.rs
+++ b/tests/unit/ci-cd/workflow_release.rs
@@ -82,6 +82,58 @@ fn documentation_deploy_uses_github_pages_artifact_flow() {
 }
 
 #[test]
+fn documentation_deploy_publishes_working_pages_root() {
+    let workflow = release_workflow();
+    let deploy_docs = job_block(&workflow, "deploy-docs");
+
+    let build_docs = deploy_docs
+        .find("- name: Build documentation")
+        .expect("deploy-docs should build rustdoc output");
+    let generate_root = deploy_docs
+        .find("- name: Generate Pages root index")
+        .expect("deploy-docs should generate a root index for GitHub Pages");
+    let verify_tree = deploy_docs
+        .find("- name: Verify site tree")
+        .expect("deploy-docs should log the artifact tree before upload");
+    let upload_artifact = deploy_docs
+        .find("- name: Upload GitHub Pages artifact")
+        .expect("deploy-docs should upload the Pages artifact");
+
+    assert!(
+        build_docs < generate_root && generate_root < verify_tree && verify_tree < upload_artifact,
+        "deploy-docs should build docs, add root Pages files, verify the tree, then upload"
+    );
+    assert!(
+        deploy_docs.contains("cargo metadata --no-deps --format-version 1"),
+        "root redirect should derive the crate docs directory from cargo metadata"
+    );
+    assert!(
+        deploy_docs.contains(r#"replace("-","_")"#),
+        "root redirect should use rustdoc's crate directory naming"
+    );
+    assert!(
+        deploy_docs.contains("target/doc/index.html"),
+        "GitHub Pages artifact should contain a root index.html"
+    );
+    assert!(
+        deploy_docs.contains("url=%s/index.html"),
+        "root index.html should redirect to the crate rustdoc index"
+    );
+    assert!(
+        deploy_docs.contains("target/doc/.nojekyll"),
+        "GitHub Pages artifact should disable Jekyll so rustdoc assets are served verbatim"
+    );
+    assert!(
+        deploy_docs.contains("include-hidden-files: true"),
+        "Pages artifact upload should include the hidden .nojekyll file"
+    );
+    assert!(
+        deploy_docs.contains("find target/doc -maxdepth 2 -print"),
+        "deploy-docs should log the published tree for easier CI diagnosis"
+    );
+}
+
+#[test]
 fn release_workflow_jobs_have_explicit_timeouts() {
     let workflow = release_workflow();
     let expected_timeouts = [


### PR DESCRIPTION
## Summary
- generate `target/doc/index.html` after `cargo doc` so the GitHub Pages root redirects to the crate rustdoc index
- add `target/doc/.nojekyll` and upload hidden files so rustdoc assets are served verbatim
- log the published docs tree and document the Pages-root behavior
- add a workflow regression test for the root redirect, `.nojekyll`, hidden-file upload, and artifact order

Fixes #79

## Reproduction
Before this change, `cargo doc --no-deps --all-features` generated `target/doc/<crate>/index.html` but no `target/doc/index.html`, so publishing `target/doc` made the Pages root return 404 while the crate subpath worked.

## Verification
- `cargo test documentation_deploy_publishes_working_pages_root --test unit` fails before the workflow change and passes after it
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features`
- `rust-script scripts/check-file-size.rs`
- `cargo test --all-features --verbose`
- `cargo test --doc --verbose`
- `GITHUB_BASE_REF=main rust-script scripts/check-changelog-fragment.rs`
- `rust-script scripts/check-cargo-lock.rs`
- `cargo build --release --verbose`
- `cargo package --list --allow-dirty`
- `rust-script scripts/check-crate-size.rs`
- local deploy-docs smoke test: build rustdoc, generate root redirect from `cargo metadata`, assert `target/doc/index.html`, `target/doc/.nojekyll`, and `target/doc/<crate>/index.html` exist
