### PR TITLE
fix: harden Cargo registry downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,10 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
+  # Harden Cargo registry index and crate downloads against transient network
+  # flakes on GitHub-hosted runners, including curl HTTP/2 framing failures.
+  CARGO_NET_RETRY: '10'
+  CARGO_HTTP_MULTIPLEXING: 'false'
   # Support both CARGO_REGISTRY_TOKEN (cargo's native env var) and CARGO_TOKEN (for backwards compatibility)
   CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
   CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-14T21:13:43.209Z for PR creation at branch issue-81-5269de7b9bce for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/81
+# Updated: 2026-06-26T21:39:23.041Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-14T21:13:43.209Z for PR creation at branch issue-81-5269de7b9bce for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/81
-# Updated: 2026-06-26T21:39:23.041Z

--- a/README.md
+++ b/README.md
@@ -271,6 +271,22 @@ cargo generate-lockfile
 git add Cargo.lock
 ```
 
+### Cargo Registry Network Hardening
+
+The release workflow sets Cargo network defaults at workflow scope so every
+Cargo command, from `cargo install rust-script` through release publishing,
+inherits them:
+
+```yaml
+CARGO_NET_RETRY: '10'
+CARGO_HTTP_MULTIPLEXING: 'false'
+```
+
+`CARGO_NET_RETRY` gives transient registry index and crate-download failures
+more chances to recover. `CARGO_HTTP_MULTIPLEXING=false` avoids libcurl HTTP/2
+multiplexing, which can fail on GitHub-hosted runners with errors such as
+`[16] Error in the HTTP2 framing layer`.
+
 ### Optional Docker Hub Publishing
 
 Projects that ship a Docker image can publish Docker Hub releases from the same Rust release workflow. Add a root `Dockerfile`, then configure:

--- a/changelog.d/20260626_214154_cargo_registry_network.md
+++ b/changelog.d/20260626_214154_cargo_registry_network.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Hardened Cargo registry downloads in the CI/CD workflow with additional retries and disabled HTTP multiplexing to reduce transient HTTP/2 framing failures.

--- a/docs/ci-cd/troubleshooting.md
+++ b/docs/ci-cd/troubleshooting.md
@@ -7,11 +7,12 @@ This guide covers common CI/CD issues and their solutions for Rust projects usin
 1. [Release Jobs Skipped](#release-jobs-skipped)
 2. [Version Already Released (False Positive)](#version-already-released-false-positive)
 3. [Missing Committed Cargo.lock](#missing-committed-cargolock)
-4. [Crates.io Publishing Fails](#cratesio-publishing-fails)
-5. [Crate Package Too Large (HTTP 413)](#crate-package-too-large-http-413)
-6. [Docker Hub Publishing Fails](#docker-hub-publishing-fails)
-7. [Secret Configuration Issues](#secret-configuration-issues)
-8. [Multi-Language Repository Issues](#multi-language-repository-issues)
+4. [Transient Cargo Registry Download Failures](#transient-cargo-registry-download-failures)
+5. [Crates.io Publishing Fails](#cratesio-publishing-fails)
+6. [Crate Package Too Large (HTTP 413)](#crate-package-too-large-http-413)
+7. [Docker Hub Publishing Fails](#docker-hub-publishing-fails)
+8. [Secret Configuration Issues](#secret-configuration-issues)
+9. [Multi-Language Repository Issues](#multi-language-repository-issues)
 
 ---
 
@@ -127,6 +128,51 @@ Run the guard locally:
 
 ```bash
 rust-script scripts/check-cargo-lock.rs
+```
+
+---
+
+## Transient Cargo Registry Download Failures
+
+### Symptom
+Cargo fails while updating the crates.io registry or downloading a crate with a
+transient network error, for example:
+
+```
+curl failed
+[16] Error in the HTTP2 framing layer
+```
+
+### Root Cause
+GitHub-hosted runners occasionally hit transient registry, CDN, or HTTP/2
+transport failures. These errors can affect any workflow step that invokes
+Cargo, including `cargo install`, `cargo build`, `cargo test`, `cargo publish`,
+and `cargo metadata`.
+
+### How This Template Prevents It
+The workflow sets Cargo network options at top-level `env` so all Cargo commands
+inherit them:
+
+```yaml
+CARGO_NET_RETRY: '10'
+CARGO_HTTP_MULTIPLEXING: 'false'
+```
+
+`CARGO_NET_RETRY` increases retry attempts for network operations.
+`CARGO_HTTP_MULTIPLEXING=false` disables libcurl HTTP multiplexing, which avoids
+the HTTP/2 framing failure mode while keeping the rest of Cargo's registry
+behavior unchanged.
+
+### Solution
+If a downstream repository has copied an older workflow, add the same top-level
+environment variables near the existing Cargo settings:
+
+```yaml
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+  CARGO_NET_RETRY: '10'
+  CARGO_HTTP_MULTIPLEXING: 'false'
 ```
 
 ---

--- a/tests/unit/ci-cd/workflow_release.rs
+++ b/tests/unit/ci-cd/workflow_release.rs
@@ -236,6 +236,27 @@ fn cargo_lock_guard_blocks_cached_cargo_jobs() {
 }
 
 #[test]
+fn release_workflow_hardens_cargo_registry_networking() {
+    let workflow = release_workflow();
+    let env_start = workflow.find("\nenv:\n").unwrap();
+    let jobs_start = workflow.find("\njobs:\n").unwrap();
+    let global_env = &workflow[env_start..jobs_start];
+
+    assert!(
+        global_env.contains("CARGO_NET_RETRY: '10'"),
+        "top-level workflow env should retry transient Cargo registry failures"
+    );
+    assert!(
+        global_env.contains("CARGO_HTTP_MULTIPLEXING: 'false'"),
+        "top-level workflow env should disable HTTP multiplexing for Cargo downloads"
+    );
+    assert!(
+        global_env.contains("HTTP/2 framing"),
+        "workflow should document the transient failure mode this hardening targets"
+    );
+}
+
+#[test]
 fn release_workflow_publishes_optional_docker_hub_image_after_crate_is_visible() {
     let workflow = release_workflow();
 


### PR DESCRIPTION
Fixes #83

## Summary
- Add workflow-level Cargo network hardening with `CARGO_NET_RETRY: '10'` and `CARGO_HTTP_MULTIPLEXING: 'false'` so every Cargo command inherits the settings.
- Document the transient HTTP/2 framing failure mode in the README and CI/CD troubleshooting guide.
- Add a workflow regression test that requires the hardening variables and failure-mode comment to stay in the top-level workflow environment.
- Add a patch changelog fragment and remove the temporary PR `.gitkeep` placeholder.

## Reproduction
Before this change, the release workflow only set `CARGO_TERM_COLOR` and `RUSTFLAGS` globally. The new `release_workflow_hardens_cargo_registry_networking` test failed because the workflow did not configure Cargo retries or disable HTTP multiplexing for registry downloads.

After the workflow update, the same test passes and verifies the hardening is inherited from top-level `env` rather than duplicated per job.

## Verification
- `cargo test release_workflow_hardens_cargo_registry_networking --test unit` failed before the workflow change and passes after it
- `cargo fmt --check`
- `git diff --check`
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets --all-features`
- `RUSTFLAGS=-Dwarnings cargo test --all-features --verbose`
- `RUSTFLAGS=-Dwarnings cargo test --doc --verbose`
- `rust-script scripts/check-file-size.rs`
- `rust-script scripts/check-cargo-lock.rs`
- `GITHUB_BASE_REF=main rust-script scripts/check-changelog-fragment.rs`
- `rust-script scripts/check-crate-size.rs`
- `cargo build --release --verbose`
- `cargo package --list --allow-dirty`
