### PR TITLE
fix: use static docs.rs release badges

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-28T18:58:22.401Z for PR creation at branch issue-85-f1cfbe75eb64 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/85

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-28T18:58:22.401Z for PR creation at branch issue-85-f1cfbe75eb64 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/85

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A comprehensive template for AI-driven Rust development with full CI/CD pipeline
 
 [![CI/CD Pipeline](https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/workflows/CI%2FCD%20Pipeline/badge.svg)](https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/actions?workflow=CI%2FCD+Pipeline)
 [![Crates.io](https://img.shields.io/crates/v/example-sum-package-name?label=crates.io&style=flat)](https://crates.io/crates/example-sum-package-name)
-[![Docs.rs](https://docs.rs/example-sum-package-name/badge.svg)](https://docs.rs/example-sum-package-name)
+[![Docs.rs](https://img.shields.io/docsrs/example-sum-package-name?label=docs.rs&style=flat)](https://docs.rs/example-sum-package-name)
 [![Rust Version](https://img.shields.io/badge/rust-1.70%2B-blue.svg)](https://www.rust-lang.org/)
 [![Codecov](https://codecov.io/gh/link-foundation/rust-ai-driven-development-pipeline-template/branch/main/graph/badge.svg)](https://codecov.io/gh/link-foundation/rust-ai-driven-development-pipeline-template)
 [![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](http://unlicense.org/)

--- a/changelog.d/20260628_190000_static_docs_rs_release_badges.md
+++ b/changelog.d/20260628_190000_static_docs_rs_release_badges.md
@@ -1,0 +1,3 @@
+### Fixed
+- Use static versioned Shields.io docs.rs badges in GitHub release notes so historical releases do not show live docs.rs build states.
+- Update the README docs.rs badge to use the Shields.io docs.rs endpoint.

--- a/scripts/create-github-release.rs
+++ b/scripts/create-github-release.rs
@@ -42,7 +42,9 @@ const USAGE: &str = "Usage: rust-script scripts/create-github-release.rs --relea
 
 const GITHUB_RELEASE_BODY_MAX_CHARS: usize = 125_000;
 
-use release_naming::{build_crates_io_badge, build_release_name, build_release_tag};
+use release_naming::{
+    build_crates_io_badge, build_docs_rs_badge, build_release_name, build_release_tag,
+};
 #[cfg(not(test))]
 use release_naming::{
     is_multi_language_rust_root, normalize_release_version, tag_prefix_for_rust_root,
@@ -171,6 +173,14 @@ fn build_release_payload(
         ),
         body,
     }
+}
+
+fn build_crate_artifact_badges(crate_name: &str, release_version: &str) -> String {
+    format!(
+        "{} {}",
+        build_crates_io_badge(crate_name, release_version),
+        build_docs_rs_badge(crate_name, release_version)
+    )
 }
 
 fn is_existing_release_error(combined: &str) -> bool {
@@ -310,11 +320,7 @@ fn main() {
     let mut badges = Vec::new();
     if !package_info.name.trim().is_empty() {
         let crate_name = &package_info.name;
-        let crate_badges = format!(
-            "{} [![Docs.rs](https://docs.rs/{crate_name}/badge.svg)](https://docs.rs/{crate_name}/{normalized_version})",
-            build_crates_io_badge(crate_name, &normalized_version)
-        );
-        badges.push(crate_badges);
+        badges.push(build_crate_artifact_badges(crate_name, &normalized_version));
     }
     if let Some(url) = docker_hub_url {
         badges.push(docker_hub_badge(&url, &normalized_version));
@@ -447,6 +453,16 @@ mod tests {
 
         assert!(badge.contains("https://crates.io/crates/web-search/0.2.1"));
         assert!(!badge.contains("rust_v0.2.1"));
+    }
+
+    #[test]
+    fn release_note_artifact_badges_use_static_docs_rs_version_badge() {
+        let badges = build_crate_artifact_badges("web-search", "rust_v0.2.1");
+
+        assert!(badges.contains("https://img.shields.io/badge/docs.rs-0.2.1-blue"));
+        assert!(badges.contains("https://docs.rs/web-search/0.2.1"));
+        assert!(!badges.contains("https://docs.rs/web-search/badge.svg"));
+        assert!(!badges.contains("rust_v0.2.1"));
     }
 
     #[test]

--- a/scripts/release-naming.rs
+++ b/scripts/release-naming.rs
@@ -121,3 +121,13 @@ pub fn build_crates_io_badge(crate_name: &str, release_version: &str) -> String 
         badge_escape(&badge_version)
     )
 }
+
+pub fn build_docs_rs_badge(crate_name: &str, release_version: &str) -> String {
+    let crate_name = crate_name.trim();
+    let normalized_semver = normalize_release_version(release_version);
+
+    format!(
+        "[![Docs.rs](https://img.shields.io/badge/docs.rs-{}-blue)](https://docs.rs/{crate_name}/{normalized_semver})",
+        badge_escape(&normalized_semver)
+    )
+}

--- a/tests/unit/ci-cd/release_naming_tests.rs
+++ b/tests/unit/ci-cd/release_naming_tests.rs
@@ -1,6 +1,6 @@
 use super::release_naming::{
-    build_crates_io_badge, build_release_name, build_release_tag, is_multi_language_rust_root,
-    normalize_release_version, tag_prefix_for_rust_root,
+    build_crates_io_badge, build_docs_rs_badge, build_release_name, build_release_tag,
+    is_multi_language_rust_root, normalize_release_version, tag_prefix_for_rust_root,
 };
 
 #[test]
@@ -59,5 +59,15 @@ fn crates_io_badge_links_to_exact_bare_version_page() {
 
     assert!(badge.contains("img.shields.io/badge/crates.io-v1.2.3-orange?logo=rust"));
     assert!(badge.contains("https://crates.io/crates/example-crate/1.2.3"));
+    assert!(!badge.contains("rust_v1.2.3"));
+}
+
+#[test]
+fn docs_rs_badge_links_to_exact_bare_version_page_without_live_status() {
+    let badge = build_docs_rs_badge("example-crate", "rust_v1.2.3");
+
+    assert!(badge.contains("img.shields.io/badge/docs.rs-1.2.3-blue"));
+    assert!(badge.contains("https://docs.rs/example-crate/1.2.3"));
+    assert!(!badge.contains("docs.rs/example-crate/badge.svg"));
     assert!(!badge.contains("rust_v1.2.3"));
 }

--- a/tests/unit/ci-cd/workflow_release.rs
+++ b/tests/unit/ci-cd/workflow_release.rs
@@ -484,3 +484,38 @@ fn release_scripts_check_configured_release_artifacts() {
         "GitHub release notes should include Docker Hub badge support"
     );
 }
+
+#[test]
+fn github_release_notes_use_static_docs_rs_badge_for_versioned_artifacts() {
+    let release_script = fs::read_to_string(format!(
+        "{}/scripts/create-github-release.rs",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .unwrap();
+    let release_naming = fs::read_to_string(format!(
+        "{}/scripts/release-naming.rs",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .unwrap();
+
+    assert!(
+        release_script.contains("build_docs_rs_badge"),
+        "GitHub release creation should render docs.rs badges through the shared release helper"
+    );
+    assert!(
+        release_naming.contains("img.shields.io/badge/docs.rs"),
+        "GitHub release notes should use a static Shields.io docs.rs badge"
+    );
+    assert!(
+        release_naming.contains("https://docs.rs/{crate_name}/{normalized_semver}"),
+        "GitHub release notes should still link to the exact docs.rs version page"
+    );
+    assert!(
+        !release_script.contains("https://docs.rs/{crate_name}/badge.svg"),
+        "GitHub release notes should not use the live docs.rs status badge"
+    );
+    assert!(
+        !release_naming.contains("https://docs.rs/{crate_name}/badge.svg"),
+        "release badge helpers should not preserve the live docs.rs status badge"
+    );
+}


### PR DESCRIPTION
Fixes #85

## Summary
- Add a shared `build_docs_rs_badge` helper that renders static versioned Shields.io docs.rs badges and links to the exact docs.rs version page.
- Use the shared helper when building GitHub release-note artifact badges so historical releases no longer display live docs.rs build-status badges.
- Update the README docs.rs badge to the Shields.io docs.rs endpoint and add regression coverage plus a changelog fragment.

## Reproduction
- Added `github_release_notes_use_static_docs_rs_badge_for_versioned_artifacts`, which failed before the fix because `scripts/create-github-release.rs` used `https://docs.rs/{crate_name}/badge.svg`.
- Added helper-level tests for the rendered release-note badge string and the docs.rs badge helper.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `rust-script scripts/check-file-size.rs` (passes with the existing 913-line warning for `scripts/version-and-commit.rs`)
- `RUST_LOG=warn rust-script scripts/check-cargo-lock.rs`
- `RUST_LOG=warn rust-script scripts/check-crate-size.rs`
- `RUST_LOG=warn rust-script scripts/create-github-release.rs --release-version rust_v1.2.3 --repository owner/repo`
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets --all-features`
- `RUSTFLAGS=-Dwarnings cargo test --all-features --verbose`
- `RUSTFLAGS=-Dwarnings cargo test --doc --verbose`