### PR TITLE
fix(ci): avoid Rust workflow false positives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,9 +196,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-lint-
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -214,7 +214,7 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     needs: [detect-changes, cargo-lock]
     # Note: always() is required because detect-changes is skipped on workflow_dispatch,
     # and without always(), this job would also be skipped even though its condition includes workflow_dispatch.
@@ -240,16 +240,28 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo registry
+      - name: Cache cargo registry on Windows
+        if: runner.os == 'Windows'
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-test-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-registry-
+
+      - name: Cache cargo registry and target on Unix
+        if: runner.os != 'Windows'
         uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-test-
 
       - name: Run tests
         run: cargo test --all-features --verbose
@@ -264,6 +276,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [detect-changes, cargo-lock]
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     if: |
       always() && !cancelled() && (
         needs.cargo-lock.result == 'success' && (
@@ -299,10 +313,17 @@ jobs:
         run: cargo llvm-cov --all-features --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
+        if: env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ env.CODECOV_TOKEN }}
           files: lcov.info
-          fail_ci_if_error: false
+          disable_search: true
+          fail_ci_if_error: true
+
+      - name: Report skipped Codecov upload
+        if: env.CODECOV_TOKEN == ''
+        run: echo "::notice::Skipping Codecov upload because CODECOV_TOKEN is not configured"
 
   # === BUILD ===
   # Build package - only runs if lint and test pass

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-03T16:06:21.058Z for PR creation at branch issue-87-3bddd0fa5097 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/87

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-03T16:06:21.058Z for PR creation at branch issue-87-3bddd0fa5097 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/87

--- a/changelog.d/20260703_160958_ci_false_positive_cleanup.md
+++ b/changelog.d/20260703_160958_ci_false_positive_cleanup.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Avoid false-positive Rust CI failures by scoping Cargo cache keys per job, skipping `target` cache uploads on Windows tests, giving the test matrix cleanup headroom, and only running Codecov uploads when `CODECOV_TOKEN` is configured.

--- a/tests/unit/ci-cd/workflow_release.rs
+++ b/tests/unit/ci-cd/workflow_release.rs
@@ -33,6 +33,26 @@ fn job_block<'a>(workflow: &'a str, job_name: &str) -> &'a str {
     )
 }
 
+fn step_block<'a>(job: &'a str, step_name: &str) -> &'a str {
+    let marker = format!("      - name: {step_name}\n");
+    let start = job
+        .find(&marker)
+        .unwrap_or_else(|| panic!("could not find workflow step {step_name:?}"));
+    let body_start = start + marker.len();
+    let rest = &job[body_start..];
+
+    let next_step = rest
+        .lines()
+        .scan(0usize, |offset, line| {
+            let current_offset = *offset;
+            *offset += line.len() + 1;
+            Some((current_offset, line))
+        })
+        .find_map(|(offset, line)| line.starts_with("      - name: ").then_some(offset));
+
+    next_step.map_or_else(|| &job[start..], |end| &job[start..body_start + end])
+}
+
 fn workflow_job_names(workflow: &str) -> Vec<&str> {
     let marker = "jobs:\n";
     let start = workflow.find(marker).unwrap() + marker.len();
@@ -142,7 +162,7 @@ fn release_workflow_jobs_have_explicit_timeouts() {
         ("version-check", 5),
         ("cargo-lock", 5),
         ("lint", 10),
-        ("test", 10),
+        ("test", 20),
         ("coverage", 15),
         ("build", 10),
         ("auto-release", 30),
@@ -166,6 +186,88 @@ fn release_workflow_jobs_have_explicit_timeouts() {
             "{job_name} should declare {expected:?}"
         );
     }
+}
+
+#[test]
+fn cargo_cache_keys_are_scoped_by_job() {
+    let workflow = release_workflow();
+
+    for (job_name, expected_key) in [
+        (
+            "lint",
+            "key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}",
+        ),
+        (
+            "coverage",
+            "key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}",
+        ),
+        (
+            "build",
+            "key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}",
+        ),
+    ] {
+        let job = job_block(&workflow, job_name);
+        assert!(
+            job.contains(expected_key),
+            "{job_name} should use a job-scoped cargo cache key"
+        );
+    }
+
+    let test = job_block(&workflow, "test");
+    assert!(
+        test.contains(
+            "key: ${{ runner.os }}-cargo-test-registry-${{ hashFiles('**/Cargo.lock') }}"
+        ),
+        "Windows test cache should use a test registry key"
+    );
+    assert!(
+        test.contains("key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}"),
+        "Unix test cache should use a test target key"
+    );
+    assert!(
+        !workflow.contains("key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}"),
+        "jobs should not share the old generic cargo cache key"
+    );
+}
+
+#[test]
+fn windows_test_cache_does_not_archive_target_directory() {
+    let workflow = release_workflow();
+    let test = job_block(&workflow, "test");
+
+    let windows_cache = step_block(test, "Cache cargo registry on Windows");
+    assert!(windows_cache.contains("if: runner.os == 'Windows'"));
+    assert!(windows_cache.contains("~/.cargo/registry"));
+    assert!(windows_cache.contains("~/.cargo/git"));
+    assert!(
+        !windows_cache.contains("\n            target\n"),
+        "Windows should not archive the large target directory during post-job cleanup"
+    );
+
+    let unix_cache = step_block(test, "Cache cargo registry and target on Unix");
+    assert!(unix_cache.contains("if: runner.os != 'Windows'"));
+    assert!(unix_cache.contains("~/.cargo/registry"));
+    assert!(unix_cache.contains("~/.cargo/git"));
+    assert!(unix_cache.contains("\n            target\n"));
+}
+
+#[test]
+fn coverage_upload_requires_token_and_reports_missing_token_as_notice() {
+    let workflow = release_workflow();
+    let coverage = job_block(&workflow, "coverage");
+    let upload = step_block(coverage, "Upload coverage to Codecov");
+
+    assert!(coverage.contains("CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}"));
+    assert!(upload.contains("if: env.CODECOV_TOKEN != ''"));
+    assert!(upload.contains("token: ${{ env.CODECOV_TOKEN }}"));
+    assert!(upload.contains("disable_search: true"));
+    assert!(upload.contains("fail_ci_if_error: true"));
+    assert!(!upload.contains("fail_ci_if_error: false"));
+
+    let skipped = step_block(coverage, "Report skipped Codecov upload");
+    assert!(skipped.contains("if: env.CODECOV_TOKEN == ''"));
+    assert!(skipped
+        .contains("::notice::Skipping Codecov upload because CODECOV_TOKEN is not configured"));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #87.

## Summary

- Scope Cargo cache keys per job so parallel lint/test jobs no longer race to save the same generic cache key.
- Split the test cache by platform: Windows caches only Cargo registry/git data, while Unix keeps caching registry/git plus `target`.
- Raise the Rust test matrix timeout from 10 to 20 minutes so successful tests have cleanup headroom.
- Gate Codecov uploads on `CODECOV_TOKEN`, emit an explicit notice when the token is missing, disable unrelated coverage search, and fail the step when an attempted upload fails.
- Add workflow-policy regression tests and a patch changelog fragment.

## Reproduction

Before the workflow change, the new workflow-policy tests reproduced the issue and failed on the current template:

- `cargo_cache_keys_are_scoped_by_job`: lint/test still shared `key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}`.
- `windows_test_cache_does_not_archive_target_directory`: the test job had no Windows registry-only cache step and archived `target` on Windows.
- `release_workflow_jobs_have_explicit_timeouts`: the test job still declared `timeout-minutes: 10`.
- `coverage_upload_requires_token_and_reports_missing_token_as_notice`: Codecov had no token gate and used `fail_ci_if_error: false`.

After the workflow update, `cargo test --test unit ci_cd::workflow_release -- --nocapture` passes with those assertions enabled.

## Verification

- `cargo test --test unit ci_cd::workflow_release -- --nocapture` failed before the workflow fix and passed after it
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features`
- `cargo test --doc`
- `RUST_LOG=error GITHUB_BASE_REF=main rust-script scripts/check-changelog-fragment.rs`
- `RUST_LOG=error rust-script scripts/check-file-size.rs` (passes with the existing warning for `scripts/version-and-commit.rs`)
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'workflow yaml parsed'"`
