### PR TITLE
fix(ci): suppress checkout default-branch warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,11 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
+  # Provide Git's initial branch before actions/checkout runs git init so
+  # Git 2.54+ does not emit the upcoming Git 3.0 default-branch hint.
+  GIT_CONFIG_COUNT: '1'
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
   # Harden Cargo registry index and crate downloads against transient network
   # flakes on GitHub-hosted runners, including curl HTTP/2 framing failures.
   CARGO_NET_RETRY: '10'

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-03T16:58:27.547Z for PR creation at branch issue-89-508a8b2599d6 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/89

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-03T16:58:27.547Z for PR creation at branch issue-89-508a8b2599d6 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/89

--- a/changelog.d/20260703_170000_git_default_branch_checkout_warning.md
+++ b/changelog.d/20260703_170000_git_default_branch_checkout_warning.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Suppress Git's default initial branch warning during release workflow checkout.

--- a/tests/unit/ci-cd/workflow_release.rs
+++ b/tests/unit/ci-cd/workflow_release.rs
@@ -67,6 +67,13 @@ fn workflow_job_names(workflow: &str) -> Vec<&str> {
         .collect()
 }
 
+fn workflow_env_block(workflow: &str) -> &str {
+    let env_start = workflow.find("\nenv:\n").unwrap();
+    let jobs_start = workflow.find("\njobs:\n").unwrap();
+
+    &workflow[env_start..jobs_start]
+}
+
 #[test]
 fn documentation_deploy_is_independent_from_release_publication() {
     let workflow = release_workflow();
@@ -340,9 +347,7 @@ fn cargo_lock_guard_blocks_cached_cargo_jobs() {
 #[test]
 fn release_workflow_hardens_cargo_registry_networking() {
     let workflow = release_workflow();
-    let env_start = workflow.find("\nenv:\n").unwrap();
-    let jobs_start = workflow.find("\njobs:\n").unwrap();
-    let global_env = &workflow[env_start..jobs_start];
+    let global_env = workflow_env_block(&workflow);
 
     assert!(
         global_env.contains("CARGO_NET_RETRY: '10'"),
@@ -355,6 +360,36 @@ fn release_workflow_hardens_cargo_registry_networking() {
     assert!(
         global_env.contains("HTTP/2 framing"),
         "workflow should document the transient failure mode this hardening targets"
+    );
+}
+
+#[test]
+fn release_workflow_sets_git_initial_branch_before_checkout() {
+    let workflow = release_workflow();
+    let global_env = workflow_env_block(&workflow);
+
+    assert!(
+        global_env.contains("GIT_CONFIG_COUNT: '1'"),
+        "top-level workflow env should declare one Git runtime config entry"
+    );
+    assert!(
+        global_env.contains("GIT_CONFIG_KEY_0: init.defaultBranch"),
+        "top-level workflow env should set the Git init default branch key"
+    );
+    assert!(
+        global_env.contains("GIT_CONFIG_VALUE_0: main"),
+        "top-level workflow env should set Git's init default branch to main"
+    );
+
+    let git_config = workflow
+        .find("GIT_CONFIG_KEY_0: init.defaultBranch")
+        .expect("workflow should set Git's default initial branch");
+    let first_checkout = workflow
+        .find("uses: actions/checkout@v6")
+        .expect("workflow should use actions/checkout");
+    assert!(
+        git_config < first_checkout,
+        "Git runtime config should be available before checkout initializes the repository"
     );
 }
 


### PR DESCRIPTION
Fixes #89.

## Summary

- Add top-level Git runtime config to `.github/workflows/release.yml` so `actions/checkout@v6` inherits `init.defaultBranch=main` before it runs `git init`.
- Add a release workflow contract test that keeps the `GIT_CONFIG_*` env values ahead of the first checkout step.
- Add a patch changelog fragment and remove the temporary PR `.gitkeep` placeholder from the final branch diff.

## Reproduction

Before the workflow update, the new `release_workflow_sets_git_initial_branch_before_checkout` test failed because the top-level workflow env did not include the Git runtime config needed by checkout.

After the workflow update, the same test passes and verifies the config is present before the first `actions/checkout@v6` step.

## Verification

- `cargo test --test unit release_workflow_sets_git_initial_branch_before_checkout` failed before the workflow fix and passed after it
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --all-features --verbose`
- `cargo test --doc --verbose`
- `cargo clippy --all-targets --all-features`
- `rust-script scripts/check-file-size.rs` (passes with the existing warning for `scripts/version-and-commit.rs`)
- `GITHUB_BASE_REF=main rust-script scripts/check-changelog-fragment.rs`
- `GITHUB_EVENT_NAME=pull_request GITHUB_HEAD_REF=issue-89-508a8b2599d6 GITHUB_BASE_REF=main rust-script scripts/check-version-modification.rs`
