### PR TITLE
fix: create release tag after push-retry loop to avoid orphaned tags

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-20T08:53:28.159Z for PR creation at branch issue-94-50b38ec8f7f2 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/94

--- a/changelog.d/20260720_000000_release_tag_after_push.md
+++ b/changelog.d/20260720_000000_release_tag_after_push.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- `scripts/version-and-commit.rs`: create the release tag after the push-retry loop succeeds, so a `pull --rebase` retry can no longer leave the tag on an orphaned pre-rebase commit (#94)

--- a/scripts/version-and-commit.rs
+++ b/scripts/version-and-commit.rs
@@ -862,19 +862,6 @@ fn main() {
     }
     println!("Committed version {}", new_version);
 
-    // Create tag
-    let tag_name = format!("{}{}", tag_prefix, new_version);
-    let tag_msg = match &description {
-        Some(desc) => format!("Release {}{}\n\n{}", tag_name, label_suffix, desc),
-        None => format!("Release {}{}", tag_name, label_suffix),
-    };
-
-    if let Err(e) = exec("git", &["tag", "-a", &tag_name, "-m", &tag_msg]) {
-        eprintln!("Error creating tag: {}", e);
-        exit(1);
-    }
-    println!("Created tag {}", tag_name);
-
     // Push changes and tag with retry (handles concurrent pushes in multi-workflow repos)
     let max_push_attempts = 3;
     for attempt in 1..=max_push_attempts {
@@ -901,6 +888,21 @@ fn main() {
             }
         }
     }
+
+    // Create tag only after the release commit is on the remote, so that a
+    // `pull --rebase` retry above can never leave the tag on an orphaned
+    // pre-rebase commit (see issue #94).
+    let tag_name = format!("{}{}", tag_prefix, new_version);
+    let tag_msg = match &description {
+        Some(desc) => format!("Release {}{}\n\n{}", tag_name, label_suffix, desc),
+        None => format!("Release {}{}", tag_name, label_suffix),
+    };
+
+    if let Err(e) = exec("git", &["tag", "-a", &tag_name, "-m", &tag_msg]) {
+        eprintln!("Error creating tag: {}", e);
+        exit(1);
+    }
+    println!("Created tag {}", tag_name);
 
     if let Err(e) = exec("git", &["push", "--tags"]) {
         eprintln!("Error pushing tags: {}", e);

--- a/tests/unit/ci-cd/mod.rs
+++ b/tests/unit/ci-cd/mod.rs
@@ -21,5 +21,6 @@ mod smoke_test_published_crate;
 #[allow(clippy::all, clippy::nursery, clippy::pedantic, dead_code)]
 #[path = "../../../scripts/version-and-commit.rs"]
 mod version_and_commit;
+mod version_and_commit_tag_order;
 mod workflow_release;
 mod workspace_manifest_resolution;

--- a/tests/unit/ci-cd/version_and_commit_tag_order.rs
+++ b/tests/unit/ci-cd/version_and_commit_tag_order.rs
@@ -1,0 +1,35 @@
+//! Regression test for issue #94: the release tag must be created only after
+//! the push-retry loop succeeds, otherwise a `pull --rebase` retry rewrites the
+//! release commit and leaves the tag on an orphaned commit.
+
+use std::fs;
+
+fn script() -> String {
+    fs::read_to_string(format!(
+        "{}/scripts/version-and-commit.rs",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .unwrap()
+    .replace("\r\n", "\n")
+}
+
+#[test]
+fn tag_is_created_after_the_push_retry_loop() {
+    let source = script();
+
+    let rebase = source
+        .find(r#"&["pull", "--rebase", "origin", &current_branch]"#)
+        .expect("push-retry rebase not found");
+    let tag = source
+        .find(r#"&["tag", "-a", &tag_name, "-m", &tag_msg]"#)
+        .expect("tag creation not found");
+    let push_tags = source
+        .find(r#"&["push", "--tags"]"#)
+        .expect("tag push not found");
+
+    assert!(
+        rebase < tag,
+        "tag must be created after the push-retry rebase, not before"
+    );
+    assert!(tag < push_tags, "tag must be created before it is pushed");
+}


### PR DESCRIPTION
Fixes #94

## Problem
`scripts/version-and-commit.rs` created the annotated release tag *before* the push-retry loop. When the retry path ran `git pull --rebase`, the release commit was rewritten and the tag stayed on the orphaned pre-rebase commit, which `git push --tags` then published.

## Fix
Move tag creation to after the push-retry loop succeeds, so the tag can only ever point at the commit that actually reached the remote.

## Test
`tests/unit/ci-cd/version_and_commit_tag_order.rs` asserts the source ordering: rebase < tag creation < `push --tags`. All 91 tests pass locally (`cargo test`, `cargo fmt --check`, `cargo clippy --all-targets` clean).

Changelog fragment added (patch bump).