### PR TITLE
fix: only rebase when actually behind origin/<branch> (#95)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-07-20T08:53:28.159Z for PR creation at branch issue-94-50b38ec8f7f2 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/94
+# Updated: 2026-07-20T09:28:03.550Z

--- a/changelog.d/20260720_120000_behind_count_before_rebase.md
+++ b/changelog.d/20260720_120000_behind_count_before_rebase.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `version-and-commit.rs` no longer reports "Local branch is behind remote" when the branch merely differs from (or is ahead of) `origin/<branch>`. It now counts `HEAD..origin/<branch>` and rebases only when actually behind, logging the real commit count (#95).

--- a/scripts/version-and-commit.rs
+++ b/scripts/version-and-commit.rs
@@ -729,11 +729,24 @@ fn main() {
     if let Err(e) = exec("git", &["fetch", "origin", &current_branch]) {
         eprintln!("Warning: Could not fetch origin/{}: {}", current_branch, e);
     } else {
-        let local = exec("git", &["rev-parse", "HEAD"]).unwrap_or_default();
-        let remote =
-            exec("git", &["rev-parse", &format!("origin/{}", current_branch)]).unwrap_or_default();
-        if !local.is_empty() && !remote.is_empty() && local != remote {
-            println!("Local branch is behind remote, rebasing...");
+        // Count the commits origin/<branch> has that HEAD does not. Being merely
+        // ahead of the remote is not being behind, and needs no rebase.
+        let behind: u32 = exec(
+            "git",
+            &[
+                "rev-list",
+                "--count",
+                &format!("HEAD..origin/{}", current_branch),
+            ],
+        )
+        .ok()
+        .and_then(|out| out.trim().parse().ok())
+        .unwrap_or(0);
+        if behind > 0 {
+            println!(
+                "Local branch is behind origin/{} by {} commit(s), rebasing...",
+                current_branch, behind
+            );
             if let Err(e) = exec("git", &["rebase", &format!("origin/{}", current_branch)]) {
                 eprintln!("Error rebasing onto origin/{}: {}", current_branch, e);
                 let _ = exec("git", &["rebase", "--abort"]);

--- a/tests/unit/ci-cd/mod.rs
+++ b/tests/unit/ci-cd/mod.rs
@@ -21,6 +21,7 @@ mod smoke_test_published_crate;
 #[allow(clippy::all, clippy::nursery, clippy::pedantic, dead_code)]
 #[path = "../../../scripts/version-and-commit.rs"]
 mod version_and_commit;
+mod version_and_commit_behind_check;
 mod version_and_commit_tag_order;
 mod workflow_release;
 mod workspace_manifest_resolution;

--- a/tests/unit/ci-cd/version_and_commit_behind_check.rs
+++ b/tests/unit/ci-cd/version_and_commit_behind_check.rs
@@ -1,0 +1,32 @@
+//! Regression test for issue #95: the pre-bump sync must only rebase when the
+//! branch is actually behind `origin/<branch>`, and must not claim "behind"
+//! merely because the local and remote SHAs differ (being ahead differs too).
+
+use std::fs;
+
+fn script() -> String {
+    fs::read_to_string(format!(
+        "{}/scripts/version-and-commit.rs",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .unwrap()
+    .replace("\r\n", "\n")
+}
+
+#[test]
+fn behind_is_measured_not_inferred_from_sha_inequality() {
+    let source = script();
+
+    assert!(
+        source.contains(r#"format!("HEAD..origin/{}", current_branch)"#),
+        "the behind-count must be computed with rev-list HEAD..origin/<branch>"
+    );
+    assert!(
+        source.contains("if behind > 0 {"),
+        "rebase must only run when the branch is actually behind"
+    );
+    assert!(
+        !source.contains("Local branch is behind remote, rebasing..."),
+        "the message must report the real behind count, not a bare SHA mismatch"
+    );
+}


### PR DESCRIPTION
Fixes #95

## Problem
`scripts/version-and-commit.rs` rebased (and logged "Local branch is behind remote") on a bare `local != remote` SHA comparison. Being *ahead* of the remote — the normal state during a release — also satisfies that condition, so the log line was false exactly when someone was debugging a failed release, and a pointless rebase ran every time.

## Fix
Count the commits `origin/<branch>` has that HEAD does not (`git rev-list --count HEAD..origin/<branch>`), rebase only when that count is > 0, and log the real number.

## Test
`tests/unit/ci-cd/version_and_commit_behind_check.rs` — source-level regression test (same style as the #94 test) asserting the behind-count is measured, the rebase is gated on `behind > 0`, and the old misleading message is gone. `cargo test` and `cargo clippy --all-targets` pass locally.