### PR TITLE
ci: add least-privilege top-level permissions to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,10 @@ on:
         required: false
         type: string
 
+# Least-privilege default for every job; jobs that need more escalate explicitly.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-07-20T08:53:28.159Z for PR creation at branch issue-94-50b38ec8f7f2 for issue https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/94
 # Updated: 2026-07-20T09:28:03.550Z
 # Updated: 2026-07-20T10:29:16.143Z
+# Updated: 2026-07-20T10:41:18.761Z

--- a/changelog.d/20260720_120000_release_permissions.md
+++ b/changelog.d/20260720_120000_release_permissions.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Security
+- Added a top-level `permissions: contents: read` block to `.github/workflows/release.yml` so jobs no longer inherit the repository's default `GITHUB_TOKEN` scope; jobs that need write access already escalate explicitly


### PR DESCRIPTION
Fixes #97

## Problem
`.github/workflows/release.yml` had no top-level `permissions:` block, so every job inherited the repository default `GITHUB_TOKEN` scope (read/write-all on many orgs).

## Fix
Added at the top of the file:
```yaml
permissions:
  contents: read
```
Verified that all jobs lacking their own `permissions:` block (detect-changes, changelog, version-check, cargo-lock, lint, test, coverage, build) only checkout/build/test and need no write scope. Jobs that do need more (auto-release, manual-release, changelog-pr, deploy-docs) already declare per-job escalation.

Also added a changelog fragment.